### PR TITLE
Don't warn about different file.encoding

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -544,7 +544,7 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
         // Add all arguments on the form '-argumentName argumentValue'
         // (i.e. in 2 separate elements of the returned String[])
         builder.withNamedArgument("httpproxy", getProxyString(settings.getActiveProxy()));
-        builder.withNamedArgument("encoding", getEncoding(true));
+        builder.withNamedArgument("encoding", getEncoding(false));
         builder.withNamedArgument("p", packageName);
         builder.withNamedArgument("target", target);
         builder.withNamedArgument("d", getOutputDirectory().getAbsolutePath());


### PR DESCRIPTION
Normally, you set project.build.sourceEncoding to tell maven and all its plugins that your sources files are in that encoding.
jaxb2 honors this setting, too. But it annoyingly warns if this encoding differs from the platform encoding:
Configured encoding [UTF-8] differs from encoding given in system property 'file.encoding' [Cp1252]
There is no clean way to have a platform independent build without that warning on windows or unix.
Therefore this patch switches the warning off.