### PR TITLE
Using canonical path also in XjcMojo

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
@@ -320,7 +320,7 @@ public class XjcMojo extends AbstractJavaGeneratorMojo {
      */
     @Override
     protected void addGeneratedSourcesToProjectSourceRoot() {
-        getProject().addCompileSourceRoot(getOutputDirectory().getAbsolutePath());
+        getProject().addCompileSourceRoot(FileSystemUtilities.getCanonicalPath(getOutputDirectory()));
     }
 
     /**


### PR DESCRIPTION
Fixes #55 by using standard `FileSystemUtilities` canonicalization instead of the simple absolute dir which may file on linked Linux paths
