### PR TITLE
Marked XjcMojo as thread safe.

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
@@ -52,7 +52,7 @@ import java.util.List;
  * @see <a href="https://jaxb.java.net/">The JAXB Reference Implementation</a>
  */
 @Mojo(name = "xjc",
-        threadSafe = false,
+        threadSafe = true,
         defaultPhase = LifecyclePhase.GENERATE_SOURCES,
         requiresDependencyResolution = ResolutionScope.COMPILE)
 public class XjcMojo extends AbstractJavaGeneratorMojo {

--- a/src/main/java/org/codehaus/mojo/jaxb2/shared/arguments/ArgumentBuilder.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/shared/arguments/ArgumentBuilder.java
@@ -211,9 +211,11 @@ public final class ArgumentBuilder {
         // Check sanity
         Validate.notEmpty(name, "name");
 
-        for (int i = 0; i < arguments.size(); i++) {
-            if (arguments.get(i).equalsIgnoreCase(name)) {
-                return i;
+        synchronized (lock) {
+            for (int i = 0; i < arguments.size(); i++) {
+                if (arguments.get(i).equalsIgnoreCase(name)) {
+                    return i;
+                }
             }
         }
 


### PR DESCRIPTION
Your plugin is thread safe: I execute it in my projects in parallel execution mode for several years now. I checked the code and found only one part that could be influenced by multiple threads:

In the class ArgumentBuilder there is one point where a List that is synchronized within blocks using a lock object (could be the manipulated object itself by the way) could be read during an updated. I added a synchronized block for it.

I checked the static class members of XjcMojo and saw, that each of it is immutable. There is no clear sign, that this plugin is not thread safe. It's worth to mark it thread-safe.