### PR TITLE
Allow rename of single generated file when no namespace defined. goal:schemagen

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
@@ -354,12 +354,18 @@ public final class XsdGeneratorHelper {
 
         // Now, rename the actual files.
         for (SimpleNamespaceResolver currentResolver : resolverMap.values()) {
-            final String localNamespaceURI = currentResolver.getLocalNamespaceURI();
+          String localNamespaceURI = currentResolver.getLocalNamespaceURI();
 
-            if (StringUtils.isEmpty(localNamespaceURI)) {
-                mavenLog.warn("SimpleNamespaceResolver contained no localNamespaceURI; aborting rename.");
-                continue;
+          if (StringUtils.isEmpty(localNamespaceURI)) {
+            if (resolverMap.size() > 1) {
+              mavenLog.warn("SimpleNamespaceResolver contained no localNamespaceURI; aborting rename.");
+              continue;
+            } else if (resolverMap.size() == 1) {
+              // only one localNamespaceURI can exist as absence of namespace
+              // do rename generated file with user value
+              localNamespaceURI = "";
             }
+          }
 
             final String newFilename = namespaceUriToDesiredFilenameMap.get(localNamespaceURI);
             final File originalFile = new File(schemaDirectory, currentResolver.getSourceFilename());


### PR DESCRIPTION
Schemagen goal.
Xsd file is always generated. But instead of forced use of default file name 'schema1.xsd' allow user to define custom file name.
#95