### PR TITLE
Fix for #60, saving proxy property values before XJC execution

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -35,6 +35,7 @@ import org.codehaus.mojo.jaxb2.shared.environment.classloading.ThreadContextClas
 import org.codehaus.mojo.jaxb2.shared.environment.locale.LocaleFacet;
 import org.codehaus.mojo.jaxb2.shared.environment.logging.LoggingHandlerEnvironmentFacet;
 import org.codehaus.mojo.jaxb2.shared.environment.sysprops.SystemPropertyChangeEnvironmentFacet;
+import org.codehaus.mojo.jaxb2.shared.environment.sysprops.SystemPropertySaveEnvironmentFacet;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 
@@ -57,6 +58,8 @@ import java.util.List;
  * @see <a href="https://jaxb.java.net/">The JAXB Reference Implementation</a>
  */
 public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
+
+    private static final List<String> PROXY_PROPERTY_KEYS = Arrays.asList("http.proxyHost", "http.proxyPort", "https.proxyHost", "https.proxyPort");
 
     private static final int XJC_COMPLETED_OK = 0;
 
@@ -443,6 +446,11 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
                     for (SystemPropertyChangeEnvironmentFacet current : sysPropChanges) {
                         environment.add(current);
                     }
+                }
+
+                // XJC overwrites proxy properties if so inclined, so we use this facet to save them
+                for (String key : PROXY_PROPERTY_KEYS) {
+                    environment.add(new SystemPropertySaveEnvironmentFacet(key, getLog()));
                 }
 
                 // Setup the environment.

--- a/src/main/java/org/codehaus/mojo/jaxb2/shared/environment/sysprops/SystemPropertySaveEnvironmentFacet.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/shared/environment/sysprops/SystemPropertySaveEnvironmentFacet.java
@@ -1,0 +1,71 @@
+package org.codehaus.mojo.jaxb2.shared.environment.sysprops;
+
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.mojo.jaxb2.shared.environment.AbstractLogAwareFacet;
+
+/**
+ * EnvironmentFacet which saves the value of a system property for the duration
+ * of executing a tool. This may be required for tools (such as the XJC tool) which
+ * may overwrite property values for its own purpose.
+ * 
+ * Unlike {@link SystemPropertyChangeEnvironmentFacet}, this does not a set a new
+ * property value itself, just saves the old value and later restores or clears it.
+ *  
+ * This facet accepts the key of the property to save.
+ *
+ * @author <a href="https://github.com/shelgen">Svein Elgst&oslash;en</a>
+ * @since 2.5
+ */
+public final class SystemPropertySaveEnvironmentFacet extends AbstractLogAwareFacet {
+    private final String key;
+    private final String originalValue;
+
+    /**
+     * Creates a SystemPropertySave which will remember the original value of the
+     * supplied system property for the duration of this SystemPropertySave.
+     *
+     * @param key A non-null key.
+     * @param log The active Maven Log.
+     */
+    public SystemPropertySaveEnvironmentFacet(final String key, final Log log) {
+        // Delegate
+        super(log);
+
+        // Assign internal state
+        this.key = key;
+        this.originalValue = System.getProperty(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void restore() {
+        if (originalValue != null) {
+            System.setProperty(key, originalValue);
+        } else {
+            System.clearProperty(key);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Restored " + toString());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setup() {
+        // Do nothing, value is saved in constructor
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setup " + toString());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SysProp key [" + key + "], saved value: [" + originalValue + "]";
+    }
+}

--- a/src/test/java/org/codehaus/mojo/jaxb2/shared/environment/sysprops/SystemPropertySaveEnvironmentFacetTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/shared/environment/sysprops/SystemPropertySaveEnvironmentFacetTest.java
@@ -1,0 +1,102 @@
+package org.codehaus.mojo.jaxb2.shared.environment.sysprops;
+
+import static org.junit.Assert.assertEquals;
+
+import org.codehaus.mojo.jaxb2.BufferingLog;
+import org.junit.Test;
+
+public class SystemPropertySaveEnvironmentFacetTest {
+    private static final String PROPERTY_KEY_NOT_SAVED = "some.other.property";
+    private static final String PROPERTY_KEY_SAVED = "http.proxyHost";
+
+    private SystemPropertySaveEnvironmentFacet createAndSetupFacet() {
+        final BufferingLog log = new BufferingLog(BufferingLog.LogLevel.DEBUG);
+        final SystemPropertySaveEnvironmentFacet facet = new SystemPropertySaveEnvironmentFacet(PROPERTY_KEY_SAVED, log);
+        facet.setup();
+        return facet;
+    }
+
+    @Test
+    public void onRestoreAfterChangeOriginalOtherPropertyValueIsNotRestored() {
+        // Given:
+        System.setProperty(PROPERTY_KEY_NOT_SAVED, "originalValue");
+        final SystemPropertySaveEnvironmentFacet facet = createAndSetupFacet();
+
+        // When:
+        System.setProperty(PROPERTY_KEY_NOT_SAVED, "changedValue");
+        facet.restore();
+
+        // Then:
+        assertEquals("changedValue", System.getProperty(PROPERTY_KEY_NOT_SAVED));
+    }
+
+    @Test
+    public void onRestoreAfterChangeOriginalSavedPropertyValueIsRestored() {
+        // Given:
+        System.setProperty(PROPERTY_KEY_SAVED, "originalValue");
+        final SystemPropertySaveEnvironmentFacet facet = createAndSetupFacet();
+
+        // When:
+        System.setProperty(PROPERTY_KEY_SAVED, "changedValue");
+        facet.restore();
+
+        // Then:
+        assertEquals("originalValue", System.getProperty(PROPERTY_KEY_SAVED));
+    }
+
+    @Test
+    public void onRestoreAfterClearOriginalOtherPropertyValueIsNotRestored() {
+        // Given:
+        System.setProperty(PROPERTY_KEY_NOT_SAVED, "originalValue");
+        final SystemPropertySaveEnvironmentFacet facet = createAndSetupFacet();
+
+        // When:
+        System.clearProperty(PROPERTY_KEY_NOT_SAVED);
+        facet.restore();
+
+        // Then:
+        assertEquals(null, System.getProperty(PROPERTY_KEY_NOT_SAVED));
+    }
+
+    @Test
+    public void onRestoreAfterClearOriginalSavedPropertyValueIsRestored() {
+        // Given:
+        System.setProperty(PROPERTY_KEY_SAVED, "originalValue");
+        final SystemPropertySaveEnvironmentFacet facet = createAndSetupFacet();
+
+        // When:
+        System.clearProperty(PROPERTY_KEY_SAVED);
+        facet.restore();
+
+        // Then:
+        assertEquals("originalValue", System.getProperty(PROPERTY_KEY_SAVED));
+    }
+
+    @Test
+    public void onRestoreAfterSetOriginallyUnsetOtherPropertyIsNotCleared() {
+        // Given:
+        System.clearProperty(PROPERTY_KEY_NOT_SAVED);
+        final SystemPropertySaveEnvironmentFacet facet = createAndSetupFacet();
+
+        // When:
+        System.setProperty(PROPERTY_KEY_NOT_SAVED, "changedValue");
+        facet.restore();
+
+        // Then:
+        assertEquals("changedValue", System.getProperty(PROPERTY_KEY_NOT_SAVED));
+    }
+
+    @Test
+    public void onRestoreAfterSetOriginallyUnsetSavedPropertyIsCleared() {
+        // Given:
+        System.clearProperty(PROPERTY_KEY_SAVED);
+        final SystemPropertySaveEnvironmentFacet facet = createAndSetupFacet();
+
+        // When:
+        System.setProperty(PROPERTY_KEY_SAVED, "changedValue");
+        facet.restore();
+
+        // Then:
+        assertEquals(null, System.getProperty(PROPERTY_KEY_SAVED));
+    }
+}


### PR DESCRIPTION
Fixes #60 

Added a facet for saving property values, or the lack of them, before tool executions.
Unfortunately the existing SystemPropertyChangeEnvironmentFacet provides no possibility of doing this if the property has no value before the tool execution.

I made use of this in AbstractJavaGeneratorMojo to save the 4 proxy property values that @efeat correctly identified as being overwritten in com.sun.tools.xjc.Options.parseArguments(String[]).

As this will clear the proxy properties after the tool execution if they were initially clear, this would solve the "loss" of nonProxyHosts due to the usage of system property overrides.