### PR TITLE
Issue #43: Work around MNG-6506 to make the build work on Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 
 jdk:
   - oraclejdk8
+  - openjdk9
+  - openjdk10
 
 addons:
   apt:

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,16 @@
         </dependency>
 
         <!--
+            Xalan dependency (to avoid subtle differences in output between Java versions)
+        -->
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.2</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!--
             Test-scope dependencies.
         -->
         <dependency>
@@ -279,12 +289,6 @@
             <groupId>se.jguru.nazgul.test.xmlbinding</groupId>
             <artifactId>nazgul-core-xmlbinding-test</artifactId>
             <version>${nazgul-core-xmlbinding-test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>2.7.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
@@ -148,6 +148,19 @@ public abstract class AbstractJaxbMojo extends AbstractMojo {
 
         // Make STANDARD_EXCLUDE_FILTERS be unmodifiable.
         STANDARD_EXCLUDE_FILTERS = Collections.unmodifiableList(tmp);
+
+        // Preload relevant package-info classes to work around MNG-6506.
+        try {
+            ClassLoader cl = AbstractJaxbMojo.class.getClassLoader();
+            cl.loadClass("com.sun.tools.xjc.addon.episode.package-info");
+            cl.loadClass("com.sun.tools.xjc.reader.xmlschema.bindinfo.package-info");
+            cl.loadClass("com.sun.xml.bind.v2.model.core.package-info");
+            cl.loadClass("com.sun.xml.bind.v2.model.runtime.package-info");
+            cl.loadClass("com.sun.xml.bind.v2.schemagen.episode.package-info");
+            cl.loadClass("com.sun.xml.bind.v2.schemagen.xmlschema.package-info");
+        } catch (ClassNotFoundException ex) {
+            throw new Error(ex);
+        }
     }
 
     /**


### PR DESCRIPTION
Also move Xalan to the runtime dependencies: some integration tests
appear to be sensitive to subtle differences in the transformer output
between Java versions.

Finally, add Java 9 and 10 to the Travis config to prevent regression.
Java 11 will require an additional fix.