### PR TITLE
Fix build on Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
   - oraclejdk8
   - openjdk9
   - openjdk10
+  - openjdk11
 
 addons:
   apt:

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <plexus-build-api.version>0.0.7</plexus-build-api.version>
 
         <!-- JAXB tooling versions -->
-        <jaxb.version>2.3.0</jaxb.version>
+        <jaxb.version>2.3.2</jaxb.version>
         <stax-ex.version>1.7.8</stax-ex.version>
         <qdox.version>2.0-M8</qdox.version>
         <asm.version>6.2.1</asm.version>
@@ -156,45 +156,12 @@
             within the JAXB RI artifacts.
         -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${jaxb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-xjc</artifactId>
-            <exclusions>
-                <!--
-                    Classes from tools.jar must be loaded by the plugin to enable schemagen.
-                    However, this hampers JDK 9 adoption.
-                -->
-                <exclusion>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-jxc</artifactId>
-            <exclusions>
-                <!--
-                    Classes from tools.jar must be loaded by the plugin to enable schemagen.
-                    However, this hampers JDK 9 adoption.
-                -->
-                <exclusion>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- QDox, used for JavaDoc processing -->
@@ -302,11 +269,6 @@
             <artifactId>logback-classic</artifactId>
             <version>1.1.7</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.istack</groupId>
-            <artifactId>istack-commons-runtime</artifactId>
-            <scope>runtime</scope>
         </dependency>
     </dependencies>
 
@@ -440,97 +402,6 @@
     </reporting>
 
     <profiles>
-
-        <profile>
-            <id>default-tools.jar</id>
-            <activation>
-                <jdk>(,9)</jdk> <!-- System.getProperty( “java.version” ) -->
-            </activation>
-
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                    <version>1.4.2</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!--
-            Augment the build module path to include javax.bind when compiling using java 9+
-
-            When: Compiling with java 9+
-        -->
-        <profile>
-            <id>jdk9</id>
-
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-
-            <properties>
-                <mojo.java.target>9</mojo.java.target>
-                <codecoverage>false</codecoverage>
-            </properties>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-jxc-jdk9</artifactId>
-                    <version>${jaxb.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-xjc-jdk9</artifactId>
-                    <version>${jaxb.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>javax.activation-api</artifactId>
-                    <version>1.2.0</version>
-                </dependency>
-            </dependencies>
-
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <version>3.5.1</version>
-                            <configuration>
-                                <source>${mojo.java.target}</source>
-                                <target>${mojo.java.target}</target>
-                                <compilerArgs>
-                                    <arg>--add-modules</arg>
-                                    <arg>java.xml.bind</arg>
-                                </compilerArgs>
-                            </configuration>
-                            <dependencies>
-                                <dependency>
-                                    <groupId>org.ow2.asm</groupId>
-                                    <artifactId>asm</artifactId>
-                                    <version>6.1.1</version> <!-- Use newer version of ASM -->
-                                </dependency>
-                            </dependencies>
-                        </plugin>
-
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>2.19.1</version>
-                            <configuration>
-                                <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
-                                <argLine>--add-modules=java.xml.bind</argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-
         <!--
             Run all integration tests, unless the "skipTests" flag is set.
 

--- a/src/it/mjaxb-14/pom.xml
+++ b/src/it/mjaxb-14/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/mjaxb-37/pom.xml
+++ b/src/it/mjaxb-37/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/mjaxb-55-partialdefaults/pom.xml
+++ b/src/it/mjaxb-55-partialdefaults/pom.xml
@@ -34,6 +34,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>se.jguru.nazgul.test.xmlbinding</groupId>
             <artifactId>nazgul-core-xmlbinding-test</artifactId>
             <version>2.1.0</version>

--- a/src/it/mjaxb-55/pom.xml
+++ b/src/it/mjaxb-55/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/mjaxb-59/module1/pom.xml
+++ b/src/it/mjaxb-59/module1/pom.xml
@@ -29,4 +29,11 @@
   </parent>
   <artifactId>mjaxb-59-module1</artifactId>
 
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/mjaxb-64/pom.xml
+++ b/src/it/mjaxb-64/pom.xml
@@ -33,6 +33,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/mjaxb-71/pom.xml
+++ b/src/it/mjaxb-71/pom.xml
@@ -35,6 +35,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/mjaxb-80/pom.xml
+++ b/src/it/mjaxb-80/pom.xml
@@ -13,6 +13,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/mjaxb-81/pom.xml
+++ b/src/it/mjaxb-81/pom.xml
@@ -33,6 +33,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-custom-converter/some_project/pom.xml
+++ b/src/it/schemagen-custom-converter/some_project/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-handles-enums/pom.xml
+++ b/src/it/schemagen-handles-enums/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-handles-package-info/pom.xml
+++ b/src/it/schemagen-handles-package-info/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-handles-xmlwrappers/pom.xml
+++ b/src/it/schemagen-handles-xmlwrappers/pom.xml
@@ -33,6 +33,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-include-sources/pom.xml
+++ b/src/it/schemagen-include-sources/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-include-test-sources/pom.xml
+++ b/src/it/schemagen-include-test-sources/pom.xml
@@ -32,6 +32,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-main/pom.xml
+++ b/src/it/schemagen-main/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-multimodule-project/first/pom.xml
+++ b/src/it/schemagen-multimodule-project/first/pom.xml
@@ -37,6 +37,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-multimodule-project/second/pom.xml
+++ b/src/it/schemagen-multimodule-project/second/pom.xml
@@ -37,6 +37,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-multimodule-project/third/pom.xml
+++ b/src/it/schemagen-multimodule-project/third/pom.xml
@@ -37,6 +37,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-platform-encoding/pom.xml
+++ b/src/it/schemagen-platform-encoding/pom.xml
@@ -28,6 +28,14 @@
 
     <description>Test of basic usage when platform encoding is used (no encoding specified)</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-rename-type/pom.xml
+++ b/src/it/schemagen-rename-type/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-test/pom.xml
+++ b/src/it/schemagen-test/pom.xml
@@ -33,6 +33,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-with-explicit-locale/pom.xml
+++ b/src/it/schemagen-with-explicit-locale/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-without-episode/pom.xml
+++ b/src/it/schemagen-without-episode/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/schemagen-work-directory/pom.xml
+++ b/src/it/schemagen-work-directory/pom.xml
@@ -34,6 +34,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-exclude-file-patterns/pom.xml
+++ b/src/it/xjc-exclude-file-patterns/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-handles-spaces-in-filenames/pom.xml
+++ b/src/it/xjc-handles-spaces-in-filenames/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-include-xsds-in-artifact/pom.xml
+++ b/src/it/xjc-include-xsds-in-artifact/pom.xml
@@ -34,6 +34,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-main/pom.xml
+++ b/src/it/xjc-main/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-mark-generated/pom.xml
+++ b/src/it/xjc-mark-generated/pom.xml
@@ -32,6 +32,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-multiple-executions/pom.xml
+++ b/src/it/xjc-multiple-executions/pom.xml
@@ -34,6 +34,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-multiple-xsd-specified/pom.xml
+++ b/src/it/xjc-multiple-xsd-specified/pom.xml
@@ -32,6 +32,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-platform-encoding/pom.xml
+++ b/src/it/xjc-platform-encoding/pom.xml
@@ -28,6 +28,14 @@
 
     <description>Test of basic usage when platform encoding is used (no encoding specified)</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/it/xjc-test/pom.xml
+++ b/src/it/xjc-test/pom.xml
@@ -32,6 +32,15 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/src/it/xjc-with-explicit-locale/pom.xml
+++ b/src/it/xjc-with-explicit-locale/pom.xml
@@ -32,6 +32,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/test/java/org/codehaus/mojo/jaxb2/shared/classloader/ThreadContextClassLoaderBuilderTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/shared/classloader/ThreadContextClassLoaderBuilderTest.java
@@ -56,7 +56,7 @@ public class ThreadContextClassLoaderBuilderTest {
     public void validateAddingURLsToThreadContextClassLoader() throws Exception {
 
         // Assemble
-        final int numExpectedResources = JavaVersion.isJdk8OrLower() ? 3 : 4;
+        final int numExpectedResources = JavaVersion.isJdk8OrLower() ? 3 : 6;
         holder = ThreadContextClassLoaderBuilder
                 .createFor(originalClassLoader, log, encoding)
                 .addURL(extraClassLoaderDirURL)


### PR DESCRIPTION
- Upgrade the JAXB implementation to 2.3.2.
- Remove the profiles that were used to work around Java compatibility
issues in previous JAXB versions.
- Remove some direct dependencies and instead rely on transitive
dependencies from JAXB (so that we don't need to adjust them when
upgrading to a new JAXB version).
- Update the integration tests to add the relevant dependencies for APIs
that were removed from the JRE in Java 11.

Fixes #43.