### PR TITLE
SimpleRegexFileFilter

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
@@ -487,7 +487,7 @@ public final class XsdGeneratorHelper {
                                                              final SimpleNamespaceResolver currentResolver)
             throws MojoExecutionException {
         // Make certain the newPrefix does not exist already.
-        if (currentResolver.getNamespaceURI2PrefixMap().containsValue(newPrefix)) {
+        if (!newPrefix.equals(oldPrefix) && currentResolver.getNamespaceURI2PrefixMap().containsValue(newPrefix)) {
             throw new MojoExecutionException(MISCONFIG + "Namespace prefix [" + newPrefix + "] is already in use."
                     + " Cannot replace namespace prefix [" + oldPrefix + "] with [" + newPrefix + "] in file ["
                     + currentResolver.getSourceFilename() + "].");

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
@@ -201,20 +201,25 @@ public class SimpleNamespaceResolver implements NamespaceContext {
             final String nodeValue = aNode.getNodeValue();
 
             // Cache the namespace in both caches.
-            final String oldUriValue = prefix2Uri.put(cacheKey, nodeValue);
-            final String oldPrefixValue = uri2Prefix.put(nodeValue, cacheKey);
 
-            // Check sanity; we should not be overwriting values here.
-            if (oldUriValue != null) {
-                throw new IllegalStateException(
-                        "Replaced URI [" + oldUriValue + "] with [" + aNode.getNodeValue() + "] for prefix [" + cacheKey
-                                + "]");
-            }
-            //If old prefix has changed, throw exception. The "tns" prefix may be overridden by a specific namespace in @XmlSchema(xmlns=...), and is therefore ignored here
-            if (oldPrefixValue != null && !oldPrefixValue.equals(cacheKey) && !oldPrefixValue.equals("tns") && !cacheKey.equals("tns")) {
-                throw new IllegalStateException(
-                        "Replaced prefix [" + oldPrefixValue + "] with [" + cacheKey + "] for URI [" + aNode.getNodeValue()
-                                + "]");
+            //"tns" must not be replaced here
+            String oldPrefix = uri2Prefix.get(nodeValue);
+            if (oldPrefix == null || !oldPrefix.equals("tns")) {
+                final String oldUriValue = prefix2Uri.put(cacheKey, nodeValue);
+                final String oldPrefixValue = uri2Prefix.put(nodeValue, cacheKey);
+
+                // Check sanity; we should not be overwriting values here.
+                if (oldUriValue != null) {
+                    throw new IllegalStateException(
+                            "Replaced URI [" + oldUriValue + "] with [" + aNode.getNodeValue() + "] for prefix [" + cacheKey
+                                    + "]");
+                }
+                //If old prefix has changed, throw exception. The "tns" prefix may be overridden by a specific namespace in @XmlSchema(xmlns=...), and is therefore ignored here
+                if (oldPrefixValue != null && !oldPrefixValue.equals(cacheKey) && !oldPrefixValue.equals("tns") && !cacheKey.equals("tns")) {
+                    throw new IllegalStateException(
+                            "Replaced prefix [" + oldPrefixValue + "] with [" + cacheKey + "] for URI [" + aNode.getNodeValue()
+                                    + "]");
+                }
             }
         }
     }

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
@@ -211,7 +211,7 @@ public class SimpleNamespaceResolver implements NamespaceContext {
                                 + "]");
             }
             //If old prefix has changed, throw exception. The "tns" prefix may be overridden by a specific namespace in @XmlSchema(xmlns=...), and is therefore ignored here
-            if (oldPrefixValue != null && !oldPrefixValue.equals(cacheKey) && !cacheKey.equals("tns")) {
+            if (oldPrefixValue != null && !oldPrefixValue.equals(cacheKey) && !oldPrefixValue.equals("tns") && !cacheKey.equals("tns")) {
                 throw new IllegalStateException(
                         "Replaced prefix [" + oldPrefixValue + "] with [" + cacheKey + "] for URI [" + aNode.getNodeValue()
                                 + "]");
@@ -219,3 +219,4 @@ public class SimpleNamespaceResolver implements NamespaceContext {
         }
     }
 }
+

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
@@ -210,7 +210,8 @@ public class SimpleNamespaceResolver implements NamespaceContext {
                         "Replaced URI [" + oldUriValue + "] with [" + aNode.getNodeValue() + "] for prefix [" + cacheKey
                                 + "]");
             }
-            if (oldPrefixValue != null) {
+            //If old prefix has changed, throw exception. The "tns" prefix may be overridden by a specific namespace in @XmlSchema(xmlns=...), and is therefore ignored here
+            if (oldPrefixValue != null && !oldPrefixValue.equals(cacheKey) && !cacheKey.equals("tns")) {
                 throw new IllegalStateException(
                         "Replaced prefix [" + oldPrefixValue + "] with [" + cacheKey + "] for URI [" + aNode.getNodeValue()
                                 + "]");

--- a/src/main/java/org/codehaus/mojo/jaxb2/shared/filters/pattern/SimpleRegexFileFilter.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/shared/filters/pattern/SimpleRegexFileFilter.java
@@ -1,0 +1,80 @@
+package org.codehaus.mojo.jaxb2.shared.filters.pattern;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.mojo.jaxb2.shared.filters.AbstractFilter;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.regex.Pattern;
+
+/**
+ * <p>Accepts all directories. Non-directory files are regex-matched against the supplied regex pattern. Uses standard
+ * java.util.regex.Pattern and java.util.regex.Matcher</p>
+ * <p>
+ * Usage:<br/>
+ * (exclude everything matching the string "MyExcludedClass"):<br/>
+ * <pre>
+ *   ...
+ *     <schemaSourceExcludeFilters>
+ *       <filter implementation="org.codehaus.mojo.jaxb2.shared.filters.pattern.SimpleRegexFileFilter">
+ *         <regex>^.*MyExcludedClass.*$</regex>
+ *       </filter>
+ *     </schemaSourceExcludeFilters>
+ *   ...
+ * </pre>
+ * or exclude everything <i>but</i> files matching "MyExcludedClass"...<br/>
+ * <pre>
+ *   ...
+ *     <schemaSourceExcludeFilters>
+ *       <filter implementation="org.codehaus.mojo.jaxb2.shared.filters.pattern.SimpleRegexFileFilter">
+ *         <regex>^((?!MyExcludedClass).)*$</regex>
+ *       </filter>
+ *     </schemaSourceExcludeFilters>
+ *   ...
+ * </pre>
+ *
+ * </p>
+ *
+ * @author <a href="mailto:markus.umefjord@gmail.com">Markus Umefjord</a>
+ * @since 2.5.1
+ */
+public class SimpleRegexFileFilter extends AbstractFilter<File> implements FileFilter {
+
+    private Pattern pattern;
+
+    /**
+     * Sets the regex string to match files against. Must be called to activate the filter. If not called, the filter will accept all files.
+     *
+     * @param regex The regex pattern to match
+     */
+    public void setRegex(String regex) {
+        this.pattern = Pattern.compile(regex);
+    }
+
+    @Override
+    protected boolean onCandidate(File pathname) {
+        if (pathname.isDirectory()) {
+            return false; //Never exclude the directories. Files are filtered below:
+        }
+        return pattern != null && pattern.matcher(pathname.getAbsolutePath()).matches();
+    }
+
+}


### PR DESCRIPTION
Adding a new possible way of configuring schemaSourceExcludeFilters, 
example of usage:

```
  ...
    <schemaSourceExcludeFilters>
      <filter implementation="org.codehaus.mojo.jaxb2.shared.filters.pattern.SimpleRegexFileFilter">
        <regex>^.*MyExcludedClass.*$</regex>
      </filter>
    </schemaSourceExcludeFilters>
  ...
</pre>

```
or exclude everything _but_ files matching "MyExcludedClass"...
```
  ...
    <schemaSourceExcludeFilters>
      <filter implementation="org.codehaus.mojo.jaxb2.shared.filters.pattern.SimpleRegexFileFilter">
        <regex>^((?!MyExcludedClass).)*$</regex>
      </filter>
    </schemaSourceExcludeFilters>
  ...
```
