### PR TITLE
Fixes #123. Support out-of-tree maven builds.

### DIFF
--- a/src/it/xjc-different-directory/pom.xml
+++ b/src/it/xjc-different-directory/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-different-directory</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Purpose: different directory test setup.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ownversion>@project.version@</ownversion>
+    </properties>
+
+	<!--
+		Nothing to build. The project is copied by the main it test over to target/it.
+		The prebuild script then creates a project in the system tmp directory and
+		compiles that.
+	-->
+</project>

--- a/src/it/xjc-different-directory/prebuild.groovy
+++ b/src/it/xjc-different-directory/prebuild.groovy
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Create a directory outside of the source tree in the system tmp directory
+// and copy our own test xsd and pom.xml there. Then run a maven build there
+// and examine the result.
+//
+// The directory in /tmp is deleted at the end of the test. Maven output
+// from the build over there is available in mvn.out and mvn.err. Find them
+// in target/it/xjc-different-directory.
+def File tmp = File.createTempFile('jaxb2it', 'diffdir')
+assert tmp.delete()
+assert tmp.mkdirs()
+try {
+    def File here = new File("${basedir}")
+    def File srcMain = new File(new File(tmp, 'src'), 'main')
+    assert srcMain.mkdirs()
+    def File src = new File(new File(here, 'testsrc'), 'simple.xsd')
+    def File tgt = new File(srcMain, 'simple.xsd')
+    tgt.bytes = src.bytes
+    // Read the version under test from our own pom
+    def File myPom = new File(here, "pom.xml")
+    def List<String> myLines = myPom.readLines()
+    def String myVersion = null
+    for (String l : myLines) {
+        if (l.contains('ownversion')) {
+            myVersion = (l =~ /<ownversion>([^<]*)<\/ownversion/)[0][1]
+            break;
+        }
+    }
+    def List<String> srcLines = new File(src.parentFile, 'pom.xml').readLines()
+    tgt = new File(tmp, 'pom.xml')
+    tgt.withWriter { out ->
+        srcLines.each {
+            out.println it.replace('@project.version@', myVersion)
+        }
+    }
+    def String cmd ='mvn clean compile ' +
+        "-Dmaven.repo.local=${basedir}${File.separator}..${File.separator}..${File.separator}local-repo " +
+        "-f ${tmp.absolutePath}${File.separator}pom.xml " +
+        '-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+    def OutputStream mvnOut = new File(here, 'mvn.out').newOutputStream()
+    mvnOut.write("Trying to run ${cmd}\n".bytes)
+    def OutputStream mvnErr = new File(here, 'mvn.err').newOutputStream()
+    def Process proc = cmd.execute()
+    try {
+        proc.waitForProcessOutput(mvnOut, mvnErr)
+    } finally {
+        mvnOut.close()
+        mvnErr.close()
+    }
+    def resultCode = proc.exitValue()
+    assert resultCode == 0
+    // Check that something was generated
+    def File generated = new File(tmp, 'target')
+    generated = new File(generated, 'generated-sources')
+    generated = new File(generated, 'jaxb')
+    generated = new File(generated, 'se')
+    generated = new File(generated, 'west')
+    generated = new File(generated, 'HasAttribute.java')
+    assert generated.isFile()
+} finally {
+    tmp.deleteDir();
+}

--- a/src/it/xjc-different-directory/testsrc/pom.xml
+++ b/src/it/xjc-different-directory/testsrc/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-different-directory-2</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Purpose: Validation of building in a different directory.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.5.1</version>
+                    <configuration>
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!--
+                        Include the sources from the supplied directory, and the supplied explicit file.
+                        The non-existent path should be silently ignored.
+                    -->
+                    <sources>
+                        <source>src/main/simple.xsd</source>
+                    </sources>
+                    <!--
+                        Use the supplied package name for the generated sources.
+                    -->
+                    <packageName>se.west</packageName>
+                    <!--
+                        Include the generated XSDs in the resulting artifact,
+                        at the supplied path.
+                    -->
+                    <xsdPathWithinArtifact>source/xsds</xsdPathWithinArtifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/xjc-different-directory/testsrc/simple.xsd
+++ b/src/it/xjc-different-directory/testsrc/simple.xsd
@@ -1,0 +1,9 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:complexType name="HasAttribute">
+    <xsd:attribute name="attr" type="xsd:string" />
+  </xsd:complexType>
+
+  <xsd:element name="withAttribute" type="HasAttribute"/>
+
+</xsd:schema>

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -659,12 +659,8 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
             final List<String> unwrappedSourceXSDs = new ArrayList<String>();
             for (URL current : sourceXSDs) {
 
-                // Shorten the argument if possible.
                 if ("file".equalsIgnoreCase(current.getProtocol())) {
-                    unwrappedSourceXSDs.add(FileSystemUtilities.relativize(
-                            current.getPath(),
-                            new File(System.getProperty("user.dir")),
-                            true));
+                    unwrappedSourceXSDs.add(current.getPath());
                 } else {
                     unwrappedSourceXSDs.add(current.toString());
                 }


### PR DESCRIPTION
Don't try to shorten paths to xsd sources. XCJ is called directly, not
via the command-line, so doing so doesn't really help. Not trying to
shorten these paths also avoids stripping a leading '/', which would
otherwise make XCJ treat the path as relative and resolve to the
current directory, which breaks out-of-tree builds.

Adds an integration test that creates a maven project in the system
tmp directory, runs a maven build there, and verifies that that maven
build was successful and did generate something.