### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+
 language: java
 
 jdk:
   - openjdk8
   - openjdk11
-
+arch:
+  - amd64
+  - ppc64le
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/jaxb2-maven-plugin/builds/191908783 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!