### PR TITLE
remove non-reproducible timestamp added by ServiceMix depends SM-5021

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin><!-- workaround for https://issues.apache.org/jira/browse/SM-5021 -->
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>fix-depends-RB</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <file>${project.build.directory}/classes/META-INF/maven/dependencies.properties</file>
+                    <replacements>
+                        <replacement>
+                            <token># Generated at: .+</token>
+                            <value>#</value>
+                        </replacement>
+                    </replacements>
+                    <regex>true</regex>
+                </configuration>
+            </plugin>
 
             <!-- Provides PlantUML integration into site deployments. -->
             <plugin>


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/SM-5021
and https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/codehaus/mojo/jaxb2-maven-plugin/README.md