### PR TITLE
For some reason schemagen does not generate the default namespace pre…

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
@@ -292,7 +292,7 @@ public final class XsdGeneratorHelper {
                     final String oldPrefix =
                             currentResolver.getNamespaceURI2PrefixMap().get(currentUri);
 
-                    if (StringUtils.isNotEmpty(oldPrefix)) {
+                    if (StringUtils.isNotEmpty(oldPrefix) && !oldPrefix.equals(newPrefix)) {
                         // Can we perform the prefix substitution?
                         validatePrefixSubstitutionIsPossible(oldPrefix, newPrefix, currentResolver);
 

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
@@ -200,17 +200,26 @@ public class SimpleNamespaceResolver implements NamespaceContext {
             final String nodeValue = aNode.getNodeValue();
 
             // Cache the namespace in both caches.
-            final String oldUriValue = prefix2Uri.put(cacheKey, nodeValue);
-            final String oldPrefixValue = uri2Prefix.put(nodeValue, cacheKey);
+            // "tns" must not be replaced here
+            String oldPrefix = uri2Prefix.get(nodeValue);
+            if (oldPrefix == null || !oldPrefix.equals("tns")) {
+                final String oldUriValue = prefix2Uri.put(cacheKey, nodeValue);
+                final String oldPrefixValue = uri2Prefix.put(nodeValue, cacheKey);
 
-            // Check sanity; we should not be overwriting values here.
-            if (oldUriValue != null) {
-                throw new IllegalStateException("Replaced URI [" + oldUriValue + "] with [" + aNode.getNodeValue()
-                        + "] for prefix [" + cacheKey + "]");
-            }
-            if (oldPrefixValue != null) {
-                throw new IllegalStateException("Replaced prefix [" + oldPrefixValue + "] with [" + cacheKey
-                        + "] for URI [" + aNode.getNodeValue() + "]");
+                // Check sanity; we should not be overwriting values here.
+                if (oldUriValue != null) {
+                    throw new IllegalStateException("Replaced URI [" + oldUriValue + "] with [" + aNode.getNodeValue()
+                            + "] for prefix [" + cacheKey + "]");
+                }
+                // If old prefix has changed, throw exception. The "tns" prefix may be overridden by a specific
+                // namespace in @XmlSchema(xmlns=...), and is therefore ignored here
+                if (oldPrefixValue != null
+                        && !oldPrefixValue.equals(cacheKey)
+                        && !oldPrefixValue.equals("tns")
+                        && !cacheKey.equals("tns")) {
+                    throw new IllegalStateException("Replaced prefix [" + oldPrefixValue + "] with [" + cacheKey
+                            + "] for URI [" + aNode.getNodeValue() + "]");
+                }
             }
         }
     }


### PR DESCRIPTION
…fix for references to simple types, such as enum types => we want to add the default namespace prefix to those nodes in order to get xjc-compatible XSD:s.