### PR TITLE
Add missing @Parameter annotation for xjc plugins

### DIFF
--- a/src/it/xjc-plugins/invoker.properties
+++ b/src/it/xjc-plugins/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult = failure

--- a/src/it/xjc-plugins/pom.xml
+++ b/src/it/xjc-plugins/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-plugins</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Test of configuring plugins of the xjc mojo.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.5.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageName>com.example.myschema</packageName>
+                    <plugins>
+                        <plugin>fluent-api</plugin>
+                        <plugin>inheritance</plugin>
+                    </plugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/xjc-plugins/src/main/xsd/address.xsd
+++ b/src/it/xjc-plugins/src/main/xsd/address.xsd
@@ -1,0 +1,16 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:complexType name="AddressType">
+    <xsd:sequence>
+      <xsd:element name="Name"   type="xsd:string"/>
+      <xsd:element name="Line1" type="xsd:string"/>
+      <xsd:element name="Line2" type="xsd:string"/>
+      <xsd:element name="City"   type="xsd:string"/>
+      <xsd:element name="State"  type="xsd:string"/>
+      <xsd:element name="ZipCode"    type="xsd:decimal"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:element name="address" type="AddressType"/>
+
+</xsd:schema>

--- a/src/it/xjc-plugins/verify.groovy
+++ b/src/it/xjc-plugins/verify.groovy
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.util.regex.Pattern
+
+File buildLog = new File(basedir, 'build.log');
+List<String> lines = buildLog.readLines();
+/*
+[DEBUG]
++=================== [14 XJC Arguments]
+|
+| [0]: -xmlschema
+| [1]: -extension
+| [2]: -encoding
+| [3]: UTF-8
+| [4]: -p
+| [5]: com.example.myschema
+| [6]: -d
+| [7]: /jaxb2-maven-plugin/target/it/xjc-plugins/target/generated-sources/jaxb
+| [8]: -classpath
+| [9]: file:/jaxb2-maven-plugin/target/local-repo/com/sun/xml/bind/jaxb-xjc/3.0.2/jaxb-xjc-3.0.2.jar!/META-INF/versions/9/;file:/jaxb2-maven-plugin/target/local-repo/com/sun/xml/bind/jaxb-core/3.0.2/jaxb-core-3.0.2.jar!/META-INF/versions/9/;file:/jaxb2-maven-plugin/target/local-repo/jakarta/xml/bind/jakarta.xml.bind-api/3.0.1/jakarta.xml.bind-api-3.0.1.jar!/META-INF/versions/9/;file:/jaxb2-maven-plugin/target/local-repo/com/sun/xml/bind/jaxb-jxc/3.0.2/jaxb-jxc-3.0.2.jar!/META-INF/versions/9/;file:/jaxb2-maven-plugin/target/local-repo/com/sun/xml/bind/jaxb-impl/3.0.2/jaxb-impl-3.0.2.jar!/META-INF/versions/9/;file:/jaxb2-maven-plugin/target/local-repo/org/codehaus/plexus/plexus-utils/4.0.1/plexus-utils-4.0.1.jar!/META-INF/versions/11/;file:/jaxb2-maven-plugin/target/local-repo/jakarta/xml/bind/jakarta.xml.bind-api/3.0.0/jakarta.xml.bind-api-3.0.0.jar!/META-INF/versions/9/
+| [10]: -episode
+| [11]: /jaxb2-maven-plugin/target/it/xjc-plugins/target/generated-sources/jaxb/META-INF/JAXB/episode_xjc.xjb
+| [12]: -Xfluent-api
+| [13]: -Xinheritance
+| [14]: /jaxb2-maven-plugin/target/it/xjc-plugins/src/main/xsd/address.xsd
+|
++=================== [End 14 XJC Arguments]
+*/
+def xjcArgumentPatternPrefix = "\\| \\[\\p{Digit}+\\]: ";
+def fluentApiPlugin = 'fluent-api';
+def inheritancePlugin = 'inheritance';
+
+final Pattern expectedFluentApiPluginPattern  = Pattern.compile(xjcArgumentPatternPrefix
+        + "-X${fluentApiPlugin}");
+final Pattern expectedInheritancePluginPattern  = Pattern.compile(xjcArgumentPatternPrefix
+        + "-X${inheritancePlugin}");
+
+
+boolean foundFluentApiPluginArgument = false;
+boolean foundInheritancePluginArgument = false;
+boolean foundExpectedErrorMessage = false;
+def expectedErrorMessage = 'Caused by: com.sun.tools.xjc.BadCommandLineException:';
+
+// Act
+for (line in lines) {
+
+    String trimmedLine = line.trim()
+    if (trimmedLine.isEmpty()) {
+        continue
+    };
+
+    if(!foundFluentApiPluginArgument && expectedFluentApiPluginPattern.matcher(trimmedLine).matches()) {
+        foundFluentApiPluginArgument = true;
+    }
+    if(!foundInheritancePluginArgument && expectedInheritancePluginPattern.matcher(trimmedLine).matches()) {
+        foundInheritancePluginArgument = true;
+    }
+    if(line.trim().startsWith(expectedErrorMessage) && line.trim().endsWith("-X${fluentApiPlugin}")) {
+        foundExpectedErrorMessage = true;
+    }
+}
+
+// Assert
+static def missingRequired(Pattern pattern) {
+    return "Missing required pattern: [" + pattern.pattern() + "]" ;
+}
+
+assert foundFluentApiPluginArgument, missingRequired(expectedFluentApiPluginPattern);
+assert foundInheritancePluginArgument, missingRequired(expectedInheritancePluginPattern);
+
+assert foundExpectedErrorMessage, "Expected XJC error message not found."

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -243,6 +243,7 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
      *
      * @since 3.2
      */
+    @Parameter(property = "xjc.plugins")
     protected List<String> plugins;
 
     /**


### PR DESCRIPTION
The new `<plugins>` config for xjc that was introduced in https://github.com/mojohaus/jaxb2-maven-plugin/pull/286 seems to be missing a `@Parameter` annotation.

I believe that this is why IntelliJ is showing validation errors in the pom.xml, and why the new configuration doesn't seem to work.

<img width="487" alt="Screenshot 2024-06-11 at 1 06 34 PM" src="https://github.com/mojohaus/jaxb2-maven-plugin/assets/684669/b4d3aff6-b83c-4de0-aabf-72517d65a6f7">
