### PR TITLE
Migrate `README.md` Build Status badge from Travis -> GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About the Jaxb2-Maven-Plugin
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.mojo/jaxb2-maven-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.mojo/jaxb2-maven-plugin)
-[![Build Status](https://travis-ci.org/mojohaus/jaxb2-maven-plugin.svg?branch=master)](https://travis-ci.org/mojohaus/jaxb2-maven-plugin)
+[![Build Status](https://github.com/mojohaus/jaxb2-maven-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/mojohaus/jaxb2-maven-plugin/actions/workflows/maven.yml)
 
 This Maven plugin uses the Java API for XML Binding (JAXB), version 2+, to perform one of 2 main tasks:
 


### PR DESCRIPTION
It _appears_ that the CI tooling has moved from [Travis](https://travis-ci.org/mojohaus/jaxb2-maven-plugin) to [GitHub Actions](https://github.com/mojohaus/jaxb2-maven-plugin/actions/workflows/maven.yml) since https://github.com/mojohaus/jaxb2-maven-plugin/commit/1b2b67524abd0ac79a62b5771c9affa3cd81fd91.

The Travis status badge is broken and should be updated to suit:
<img width="544" alt="image" src="https://github.com/user-attachments/assets/2f0cb129-94d2-4122-acc3-6ac3d9869bd5" />
