### PR TITLE
refs #346: Prevent extra empty lines on schema generation

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
@@ -466,7 +466,7 @@ public final class XsdGeneratorHelper {
 
         try {
             Transformer transformer = getFactory().newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty(OutputKeys.INDENT, "no");
             transformer.setOutputProperty(OutputKeys.STANDALONE, "yes");
             transformer.transform(new DOMSource(node), new StreamResult(toReturn));
         } catch (TransformerException e) {


### PR DESCRIPTION
Prevented unnecessary vertical indentation when inserting javadocs, changing namespace prefixes and rename output files.