### PR TITLE
When generating Java code a couple of messages are swallowed by the given logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ local.properties
 .loadpath
 .project
 .classpath
+.factorypath
 
 # External tool builders
 .externalToolBuilders/

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapter.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapter.java
@@ -63,6 +63,16 @@ public class XjcLogAdapter extends XJCListener {
      * {@inheritDoc}
      */
     @Override
+    public void message(String msg) {
+        if (log.isDebugEnabled()) {
+            log.debug(msg);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void error(final SAXParseException exception) {
         log.error(getLocation(exception), exception);
     }

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapter.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapter.java
@@ -63,7 +63,7 @@ public class XjcLogAdapter extends XJCListener {
      * {@inheritDoc}
      */
     @Override
-    public void message(String msg) {
+    public void message(final String msg) {
         if (log.isDebugEnabled()) {
             log.debug(msg);
         }


### PR DESCRIPTION
The `AbstractJavaGeneratorMojo` uses an adapter implementation to emit XJC events to the plugins log. Unfortunately the implementation doesn't override `XJCListener#message()`, a method that is used a couple of times in `com.sun.tools.xjc.Driver`. The default implementation simply does nothing, i.e. a couple of messages are swallowed during plugin execution.

This PR fixes this by providing an implementation that sends these messages to the debug output.