### PR TITLE
Fix GitHub #313

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilities.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilities.java
@@ -539,12 +539,14 @@ public final class FileSystemUtilities {
         String platformSpecificPath;
         if (p.normalize().startsWith(pd.normalize().toString())) {
             platformSpecificPath = pd.relativize(p).toString();
+
+            // Only strip the leading file separator when the path was actually relativized.
+            // When the path is not under parentDir the result stays absolute and the separator must be kept.
+            if (removeInitialFileSep && platformSpecificPath.startsWith(File.separator)) {
+                platformSpecificPath = platformSpecificPath.substring(File.separator.length());
+            }
         } else {
             platformSpecificPath = p.toString();
-        }
-
-        if (removeInitialFileSep && platformSpecificPath.startsWith(File.separator)) {
-            platformSpecificPath = platformSpecificPath.substring(File.separator.length());
         }
 
         // NOTE: it appears this function is meant to preserve the file separator that was passed in the path

--- a/src/test/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilitiesTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilitiesTest.java
@@ -432,10 +432,11 @@ class FileSystemUtilitiesTest {
         final String path = "/project/backend/foobar/my-schema.xsd";
         final SortedMap<String, String> parentDir2Expected = new TreeMap<>();
         parentDir2Expected.put("/", "project/backend/foobar/my-schema.xsd");
-        parentDir2Expected.put("", "project/backend/foobar/my-schema.xsd");
         parentDir2Expected.put("/project", "backend/foobar/my-schema.xsd");
-        parentDir2Expected.put("/not/a/path", "project/backend/foobar/my-schema.xsd");
         parentDir2Expected.put("/project/", "backend/foobar/my-schema.xsd");
+        // When path is NOT under parentDir, the absolute path must be preserved (GitHub #313)
+        parentDir2Expected.put("", "/project/backend/foobar/my-schema.xsd");
+        parentDir2Expected.put("/not/a/path", "/project/backend/foobar/my-schema.xsd");
 
         // Act & Assert
         for (Map.Entry<String, String> current : parentDir2Expected.entrySet()) {


### PR DESCRIPTION
- Fixes #313 
- Only strip the leading file separator when the path was actually relativized.
- When the path is not under parentDir the result stays absolute and the separator must be kept.