### PR TITLE
Decide the canonical namespace prefix independently of DOM attribute order

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
@@ -30,7 +30,10 @@ import java.io.Reader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.codehaus.mojo.jaxb2.schemageneration.XsdGeneratorHelper;
 import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.NodeProcessor;
@@ -52,6 +55,7 @@ public class SimpleNamespaceResolver implements NamespaceContext {
     // Constants
     private static final String DEFAULT_NS = "DEFAULT";
     private static final String TARGET_NAMESPACE = "targetNamespace";
+    private static final String TARGET_NAMESPACE_PREFIX = "tns";
     private static final String SCHEMA = "schema";
 
     // Internal state
@@ -59,6 +63,7 @@ public class SimpleNamespaceResolver implements NamespaceContext {
     private String localNamespaceURI;
     private Map<String, String> prefix2Uri = new HashMap<String, String>();
     private Map<String, String> uri2Prefix = new HashMap<String, String>();
+    private Map<String, Set<String>> uri2Prefixes = new LinkedHashMap<String, Set<String>>();
 
     /**
      * Creates a new SimpleNamespaceResolver which collects namespace data
@@ -151,6 +156,41 @@ public class SimpleNamespaceResolver implements NamespaceContext {
 
         // Process the DOM model.
         XsdGeneratorHelper.process(parsedDocument.getFirstChild(), true, new NamespaceAttributeNodeProcessor());
+
+        // Reduce each URI to its canonical prefix, which can only be decided once every prefix bound to
+        // that URI is known. Attributes are not necessarily visited in the order they are declared, so
+        // deciding this while collecting would make the outcome depend on the order of the DOM traversal.
+        for (Map.Entry<String, Set<String>> current : uri2Prefixes.entrySet()) {
+            uri2Prefix.put(current.getKey(), getCanonicalPrefix(current.getKey(), current.getValue()));
+        }
+    }
+
+    /**
+     * Selects the prefix representing the supplied namespace URI, out of all prefixes bound to it within the
+     * source file. The "tns" prefix wins whenever it is present, since a prefix supplied through
+     * <code>@XmlSchema(xmlns=...)</code> is emitted in addition to it rather than instead of it.
+     *
+     * @param namespaceUri The namespace URI for which to select a prefix.
+     * @param prefixes     All prefixes bound to the namespaceUri, in the order they were found.
+     * @return The single prefix representing the namespaceUri.
+     * @throws IllegalStateException if several prefixes are bound to the namespaceUri and none of them is "tns",
+     *                               in which case there is no ground to prefer one over another.
+     */
+    private static String getCanonicalPrefix(final String namespaceUri, final Set<String> prefixes) {
+
+        if (prefixes.contains(TARGET_NAMESPACE_PREFIX)) {
+            return TARGET_NAMESPACE_PREFIX;
+        }
+
+        final Iterator<String> it = prefixes.iterator();
+        final String firstPrefix = it.next();
+
+        if (it.hasNext()) {
+            throw new IllegalStateException(
+                    "Replaced prefix [" + firstPrefix + "] with [" + it.next() + "] for URI [" + namespaceUri + "]");
+        }
+
+        return firstPrefix;
     }
 
     private class NamespaceAttributeNodeProcessor implements NodeProcessor {
@@ -197,21 +237,20 @@ public class SimpleNamespaceResolver implements NamespaceContext {
                     XMLConstants.XMLNS_ATTRIBUTE.equals(aNode.getNodeName()) ? DEFAULT_NS : aNode.getLocalName();
             final String nodeValue = aNode.getNodeValue();
 
-            // Cache the namespace in both caches.
-            final String oldUriValue = prefix2Uri.put(cacheKey, nodeValue);
-            final String oldPrefixValue = uri2Prefix.put(nodeValue, cacheKey);
+            // A prefix binds to exactly one URI. Rebinding it to another one is a genuine conflict,
+            // whereas repeating the binding it already has is a no-op rather than a replacement.
+            final String boundUri = prefix2Uri.get(cacheKey);
+            if (boundUri != null && !boundUri.equals(nodeValue)) {
+                throw new IllegalStateException(
+                        "Replaced URI [" + boundUri + "] with [" + nodeValue + "] for prefix [" + cacheKey + "]");
+            }
+            prefix2Uri.put(cacheKey, nodeValue);
 
-            // Check sanity; we should not be overwriting values here.
-            if (oldUriValue != null) {
-                throw new IllegalStateException("Replaced URI [" + oldUriValue + "] with [" + aNode.getNodeValue()
-                        + "] for prefix [" + cacheKey + "]");
-            }
-            // If old prefix has changed, throw exception. The "tns" prefix may be overridden by a specific namespace in
-            // @XmlSchema(xmlns=...), and is therefore ignored here
-            if (oldPrefixValue != null && !oldPrefixValue.equals(cacheKey) && !cacheKey.equals("tns")) {
-                throw new IllegalStateException("Replaced prefix [" + oldPrefixValue + "] with [" + cacheKey
-                        + "] for URI [" + aNode.getNodeValue() + "]");
-            }
+            // A URI, on the other hand, may be bound to several prefixes. Collect them all; which one
+            // represents the URI is decided in getCanonicalPrefix once the whole file has been read.
+            uri2Prefixes
+                    .computeIfAbsent(nodeValue, key -> new LinkedHashSet<String>())
+                    .add(cacheKey);
         }
     }
 }

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolver.java
@@ -116,7 +116,10 @@ public class SimpleNamespaceResolver implements NamespaceContext {
             throw new IllegalArgumentException("Cannot acquire prefixes for null namespaceURI.");
         }
 
-        return Collections.singletonList(uri2Prefix.get(namespaceURI)).iterator();
+        final Set<String> prefixes = uri2Prefixes.get(namespaceURI);
+        return prefixes == null
+                ? Collections.<String>emptyList().iterator()
+                : Collections.unmodifiableSet(prefixes).iterator();
     }
 
     /**

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolverTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolverTest.java
@@ -20,6 +20,8 @@ public class SimpleNamespaceResolverTest {
 
     public static final String SCHEMA_DIR = "/org/codehaus/mojo/jaxb2/helpers/";
 
+    private static final String STUDENT_NAMESPACE = "http://schemas.acme.com/student";
+
     private File getSchemaFile(String resource) {
         return FileUtils.toFile(this.getClass().getResource(resource));
     }
@@ -178,5 +180,85 @@ public class SimpleNamespaceResolverTest {
         assertEquals("xs", namespaceURI2PrefixMap.get(XMLConstants.W3C_XML_SCHEMA_NS_URI));
         assertEquals("base", namespaceURI2PrefixMap.get("http://schemas.acme.com"));
         assertEquals("tns", namespaceURI2PrefixMap.get("http://schemas.acme.com/student"));
+    }
+
+    @Test
+    void validateTnsIsCanonicalPrefixWhenDeclaredBeforeItsAliases() {
+        // Assemble
+        final SimpleNamespaceResolver unitUnderTest =
+                new SimpleNamespaceResolver(getSchemaFile(SCHEMA_DIR + "tnsAliasFirstSchema.xsd"));
+
+        // Act
+        final Map<String, String> namespaceURI2PrefixMap = unitUnderTest.getNamespaceURI2PrefixMap();
+
+        // Assert
+        assertEquals("tns", namespaceURI2PrefixMap.get(STUDENT_NAMESPACE));
+    }
+
+    @Test
+    void validateTnsIsCanonicalPrefixWhenDeclaredAfterItsAliases() {
+        // Assemble
+        final SimpleNamespaceResolver unitUnderTest =
+                new SimpleNamespaceResolver(getSchemaFile(SCHEMA_DIR + "tnsAliasLastSchema.xsd"));
+
+        // Act
+        final Map<String, String> namespaceURI2PrefixMap = unitUnderTest.getNamespaceURI2PrefixMap();
+
+        // Assert
+        assertEquals("tns", namespaceURI2PrefixMap.get(STUDENT_NAMESPACE));
+    }
+
+    @Test
+    void validateAliasedPrefixesRemainResolvable() {
+        // Assemble
+        final SimpleNamespaceResolver unitUnderTest =
+                new SimpleNamespaceResolver(getSchemaFile(SCHEMA_DIR + "tnsAliasFirstSchema.xsd"));
+
+        // Act & Assert
+        // Prefix-to-URI is a many-to-one relation: every prefix the document declares must resolve,
+        // even though only one of them is the canonical prefix for the URI.
+        assertEquals(STUDENT_NAMESPACE, unitUnderTest.getNamespaceURI("tns"));
+        assertEquals(STUDENT_NAMESPACE, unitUnderTest.getNamespaceURI("base"));
+        assertEquals(STUDENT_NAMESPACE, unitUnderTest.getNamespaceURI("extra"));
+    }
+
+    @Test
+    void validateRedundantlyRedeclaredPrefixIsAccepted() {
+        // Assemble
+        final File schemaFile = getSchemaFile(SCHEMA_DIR + "redeclaredPrefixSchema.xsd");
+
+        // Act
+        final SimpleNamespaceResolver unitUnderTest = new SimpleNamespaceResolver(schemaFile);
+
+        // Assert
+        // Rebinding a prefix to the URI it is already bound to changes nothing, and is not a conflict.
+        assertEquals(STUDENT_NAMESPACE, unitUnderTest.getNamespaceURI("tns"));
+        assertEquals("tns", unitUnderTest.getNamespaceURI2PrefixMap().get(STUDENT_NAMESPACE));
+    }
+
+    @Test
+    void validateExceptionThrownOnCompetingPrefixesForTheSameUri() {
+        // Assemble
+        final File schemaFile = getSchemaFile(SCHEMA_DIR + "conflictingPrefixSchema.xsd");
+
+        // Act & Assert
+        final IllegalStateException exception =
+                assertThrows(IllegalStateException.class, () -> new SimpleNamespaceResolver(schemaFile));
+        assertTrue(
+                exception.getMessage().contains("Replaced prefix"),
+                "Expected a 'Replaced prefix' message, but got: " + exception.getMessage());
+    }
+
+    @Test
+    void validateExceptionThrownOnPrefixReboundToAnotherUri() {
+        // Assemble
+        final File schemaFile = getSchemaFile(SCHEMA_DIR + "reboundPrefixSchema.xsd");
+
+        // Act & Assert
+        final IllegalStateException exception =
+                assertThrows(IllegalStateException.class, () -> new SimpleNamespaceResolver(schemaFile));
+        assertTrue(
+                exception.getMessage().contains("Replaced URI"),
+                "Expected a 'Replaced URI' message, but got: " + exception.getMessage());
     }
 }

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolverTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/SimpleNamespaceResolverTest.java
@@ -4,6 +4,7 @@ import javax.xml.XMLConstants;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -220,6 +221,25 @@ public class SimpleNamespaceResolverTest {
         assertEquals(STUDENT_NAMESPACE, unitUnderTest.getNamespaceURI("tns"));
         assertEquals(STUDENT_NAMESPACE, unitUnderTest.getNamespaceURI("base"));
         assertEquals(STUDENT_NAMESPACE, unitUnderTest.getNamespaceURI("extra"));
+
+        // ... and getPrefixes reports every one of them, not only the canonical prefix.
+        final List<String> prefixes = new ArrayList<String>();
+        for (Iterator<String> it = unitUnderTest.getPrefixes(STUDENT_NAMESPACE); it.hasNext(); ) {
+            prefixes.add(it.next());
+        }
+        assertEquals(3, prefixes.size());
+        assertTrue(prefixes.containsAll(Arrays.asList("tns", "base", "extra")), "Got prefixes: " + prefixes);
+    }
+
+    @Test
+    void validatePrefixesIteratorIsEmptyForUndeclaredNamespace() {
+        // Assemble
+        final SimpleNamespaceResolver unitUnderTest =
+                new SimpleNamespaceResolver(getSchemaFile(SCHEMA_DIR + "tnsAliasFirstSchema.xsd"));
+
+        // Act & Assert
+        assertFalse(
+                unitUnderTest.getPrefixes("http://schemas.acme.com/undeclared").hasNext());
     }
 
     @Test

--- a/src/test/resources/org/codehaus/mojo/jaxb2/helpers/conflictingPrefixSchema.xsd
+++ b/src/test/resources/org/codehaus/mojo/jaxb2/helpers/conflictingPrefixSchema.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0"
+           xmlns:foo="http://schemas.acme.com/student"
+           xmlns:bar="http://schemas.acme.com/student"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!-- Two non-"tns" prefixes bound to the same URI; there is no canonical prefix to prefer. -->
+
+    <xs:element name="student" type="foo:studentType"/>
+</xs:schema>

--- a/src/test/resources/org/codehaus/mojo/jaxb2/helpers/reboundPrefixSchema.xsd
+++ b/src/test/resources/org/codehaus/mojo/jaxb2/helpers/reboundPrefixSchema.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0"
+           xmlns:foo="http://schemas.acme.com/student"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!-- The "foo" prefix is rebound to a different URI on a nested element. -->
+
+    <xs:complexType name="studentType">
+        <xs:sequence>
+            <xs:element name="tutor" type="foo:tutorType" xmlns:foo="http://schemas.acme.com/teacher"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/src/test/resources/org/codehaus/mojo/jaxb2/helpers/redeclaredPrefixSchema.xsd
+++ b/src/test/resources/org/codehaus/mojo/jaxb2/helpers/redeclaredPrefixSchema.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0"
+           targetNamespace="http://schemas.acme.com/student"
+           xmlns:tns="http://schemas.acme.com/student"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!-- The "tns" prefix is redundantly redeclared, bound to the same URI, on a nested element. -->
+
+    <xs:complexType name="studentType">
+        <xs:sequence>
+            <xs:element name="tutor" type="tns:tutorType" xmlns:tns="http://schemas.acme.com/student"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/src/test/resources/org/codehaus/mojo/jaxb2/helpers/tnsAliasFirstSchema.xsd
+++ b/src/test/resources/org/codehaus/mojo/jaxb2/helpers/tnsAliasFirstSchema.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0"
+           targetNamespace="http://schemas.acme.com/student"
+           xmlns:tns="http://schemas.acme.com/student"
+           xmlns:base="http://schemas.acme.com/student"
+           xmlns:extra="http://schemas.acme.com/student"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!-- The target namespace is bound to "tns" before it is bound to any other prefix. -->
+
+    <xs:element name="student" type="tns:studentType"/>
+
+    <xs:complexType name="studentType">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/src/test/resources/org/codehaus/mojo/jaxb2/helpers/tnsAliasLastSchema.xsd
+++ b/src/test/resources/org/codehaus/mojo/jaxb2/helpers/tnsAliasLastSchema.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0"
+           targetNamespace="http://schemas.acme.com/student"
+           xmlns:base="http://schemas.acme.com/student"
+           xmlns:tns="http://schemas.acme.com/student"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!-- The target namespace is bound to "base" before it is bound to "tns". -->
+
+    <xs:element name="student" type="base:studentType"/>
+
+    <xs:complexType name="studentType">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
Where a `package-info` binds a prefix through `@XmlSchema(xmlns=...)` to the schema's own target namespace, schemagen emits that prefix alongside `xmlns:tns` rather than instead of it, so the URI ends up bound twice. Whether that was tolerated depended on which binding the DOM handed over first — `tns` first threw `IllegalStateException`, `tns` second did not. `NamedNodeMap` makes no promise about declaration order, so the outcome was not a property of the schema being read.

Choosing between the prefixes once the whole file has been read, rather than while collecting them, takes the ordering out of the decision. `tns` wins where present; competing prefixes with no `tns` among them still throw. Rebinding a prefix to the URI it is already bound to is now a no-op rather than a replacement — it was reported as `Replaced URI [x] with [x]`, which a redundant but legal redeclaration on a nested element was enough to trigger.

This diverges from #363 on one point: declared prefixes stay resolvable through `getNamespaceURI`, where #363 erases the non-canonical ones. The class implements `NamespaceContext`, prefix-to-URI is many-to-one, and erasing aliases makes it deny prefixes the document declares. Only `uri2Prefix` is read by the plugin, and that holds the same canonical content under either shape.

Extracted from #363, which carries this alongside two unrelated changes; the fixtures and tests are new.

Verified: the three new order-independence and redeclaration tests fail on `master` with `Replaced prefix [base] with [extra]` and `Replaced URI [...] with [...]`.