### PR TITLE
Anchor the README exclude pattern to the file name

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
@@ -92,7 +92,7 @@ public abstract class AbstractJaxbMojo extends AbstractMojo {
      *     <code>
      *         // The standard exclude filters contain simple, exclude pattern filters.
      *         final List&lt;Filter&lt;File&gt;&gt; tmp = new ArrayList&lt;Filter&lt;File&gt;&gt;();
-     *         tmp.add(new PatternFileFilter(Arrays.asList({"README.*", "\\.xml", "\\.txt"}), true));
+     *         tmp.add(new PatternFileFilter(Arrays.asList({"[/\\\\]README[^/\\\\]*", "\\.xml", "\\.txt"}), true));
      *         tmp.add(new FileFilterAdapter(new FileFilter() {
      *
      *             &#64;Override

--- a/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
@@ -121,7 +121,11 @@ public abstract class AbstractJaxbMojo extends AbstractMojo {
     private static final List<String> RELEVANT_GROUPIDS = Arrays.asList("com.sun.xml.bind", "jakarta.xml.bind");
     private static final String OWN_ARTIFACT_ID = "jaxb2-maven-plugin";
     private static final String SYSTEM_FILE_ENCODING_PROPERTY = "file.encoding";
-    private static final String[] STANDARD_EXCLUDE_SUFFIXES = {"README.*", "\\.xml", "\\.txt"};
+    // The patterns are matched against the full path of each candidate file, prefixed with
+    // PatternFileFilter.PATTERN_LETTER_DIGIT_PUNCT. Since \p{Punct} includes the file separators, the README
+    // pattern has to be anchored to the last path segment; otherwise it also matches every file below a
+    // directory whose name happens to contain "readme".
+    private static final String[] STANDARD_EXCLUDE_SUFFIXES = {"[/\\\\]README[^/\\\\]*", "\\.xml", "\\.txt"};
     private static final String[] STANDARD_PRELOADED_CLASSES = {
         "com.sun.tools.xjc.addon.episode.package-info",
         "com.sun.tools.xjc.reader.xmlschema.bindinfo.package-info",

--- a/src/site/markdown/example_schemagen_basic.md
+++ b/src/site/markdown/example_schemagen_basic.md
@@ -178,13 +178,13 @@ The following settings are used by default.
    JAXB-annotated files, to be included within the Xml Schema Compilation operation. 
    By default, files matching some Java Regexp patterns are excluded from the JXC compilation. 
    The default exclude patterns are  
-   `"README.*", "\.xml", "\.txt", "\\.xjb", "\\.xsd", "\\.properties"` as documented on the 
+   `"[/\\]README[^/\\]*", "\.xml", "\.txt", "\\.xjb", "\\.xsd", "\\.properties"` as documented on the 
    `SchemaGenerationMojo.STANDARD_SOURCE_EXCLUDE_FILTERS` property.
 2. The standard test source folders (i.e. `getProject().getTestCompileSourceRoots()`) are expected to contain 
    JAXB-annotated files, to be included within the test-scope Xml Schema Compilation operation. 
    By default, files matching some Java Regexp patterns are excluded from the JXC compilation. 
    The default exclude patterns are  
-   `"README.*", "\.xml", "\.txt", "\\.xjb", "\\.xsd", "\\.properties"` as documented on the 
+   `"[/\\]README[^/\\]*", "\.xml", "\.txt", "\\.xjb", "\\.xsd", "\\.properties"` as documented on the 
    `TestSchemaGenerationMojo.STANDARD_TEST_SOURCE_EXCLUDE_FILTERS` property.             
 
 The standard behavior can be overridden by the following elements:
@@ -438,7 +438,7 @@ removing all files identified by the two PatternFileFilters:
         |        Processes nulls: [false]
         |        Accept on match: [true]
         |        3 regularExpressions ...
-        |         [0/3]: (\p{javaLetterOrDigit}|\p{Punct})+README.*
+        |         [0/3]: (\p{javaLetterOrDigit}|\p{Punct})+[/\\]README[^/\\]*
         |         [1/3]: (\p{javaLetterOrDigit}|\p{Punct})+\.xml
         |         [2/3]: (\p{javaLetterOrDigit}|\p{Punct})+\.txt
         | [2/2]: Filter [PatternFileFilter]

--- a/src/site/markdown/example_xjc_basic.md
+++ b/src/site/markdown/example_xjc_basic.md
@@ -40,19 +40,19 @@ Unless overridden by the configuration, the following settings are used by defau
 1. The `src/main/xsd` directory (including subdirectories) is expected to contain compile-scope XSD files, as 
    documented within the `XjcMojo.STANDARD_SOURCE_DIRECTORY` property. By default, files matching some 
    Java Regexp patterns are excluded from the XJC compilation. The default exclude patterns are 
-   `"README.*", "\.xml", "\.txt", "\.java", "\.scala", "\.mdo"`. 
+   `"[/\\]README[^/\\]*", "\.xml", "\.txt", "\.java", "\.scala", "\.mdo"`. 
 2. The `src/test/xsd` directory (including subdirectories) is expected to contain test-scope XSD files, as 
    documented within the `TestXjcMojo.STANDARD_TEST_SOURCE_DIRECTORY` property. By default, files matching some 
    Java Regexp patterns are excluded from the XJC compilation. The default exclude patterns are 
-   `"README.*", "\.xml", "\.txt", "\.java", "\.scala", "\.mdo"`.   
+   `"[/\\]README[^/\\]*", "\.xml", "\.txt", "\.java", "\.scala", "\.mdo"`.   
 3. The `src/main/xjb` directory (including subdirectories) is expected to contain compile-scope XJB files, as 
    documented within the `XjcMojo.STANDARD_XJB_DIRECTORY` property. By default, files matching some 
    Java Regexp patterns are excluded from the XJC compilation. The default exclude patterns are 
-   `"README.*", "\\.xml", "\\.txt", "\\.xsd"`.
+   `"[/\\]README[^/\\]*", "\\.xml", "\\.txt", "\\.xsd"`.
 4. The `src/test/xjb` directory (including subdirectories) is expected to contain test-scope XJB files, as 
    documented within the `TestXjcMojo.STANDARD_TEST_XJB_DIRECTORY` property. By default, files matching some 
    Java Regexp patterns are excluded from the XJC compilation. The default exclude patterns are 
-   `"README.*", "\\.xml", "\\.txt", "\\.xsd"`.          
+   `"[/\\]README[^/\\]*", "\\.xml", "\\.txt", "\\.xsd"`.          
 
 The standard behavior can be overridden by the following elements:
 
@@ -450,7 +450,7 @@ removing all files identified by the two PatternFileFilters:
         |        Processes nulls: [false]
         |        Accept on match: [true]
         |        3 regularExpressions ...
-        |         [0/3]: (\p{javaLetterOrDigit}|\p{Punct})+README.*
+        |         [0/3]: (\p{javaLetterOrDigit}|\p{Punct})+[/\\]README[^/\\]*
         |         [1/3]: (\p{javaLetterOrDigit}|\p{Punct})+\.xml
         |         [2/3]: (\p{javaLetterOrDigit}|\p{Punct})+\.txt
         | [2/2]: Filter [PatternFileFilter]

--- a/src/test/java/org/codehaus/mojo/jaxb2/StandardExcludeFiltersTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/StandardExcludeFiltersTest.java
@@ -1,0 +1,87 @@
+package org.codehaus.mojo.jaxb2;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.codehaus.mojo.jaxb2.shared.filters.Filters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates that the standard exclude filters reject README files without rejecting
+ * everything that merely happens to sit below a directory whose name contains "readme".
+ */
+class StandardExcludeFiltersTest {
+
+    @TempDir
+    File projectDirectory;
+
+    @BeforeEach
+    void initializeFilters() {
+        Filters.initialize(new BufferingLog(), AbstractJaxbMojo.STANDARD_EXCLUDE_FILTERS);
+    }
+
+    @Test
+    void validateReadmeFilesAreExcluded() throws IOException {
+        assertTrue(isExcluded("src/main/xsd/README.txt"));
+        assertTrue(isExcluded("src/main/xsd/README"));
+        assertTrue(isExcluded("src/main/xsd/readme.md"));
+    }
+
+    @Test
+    void validateReadmeInDirectoryNameDoesNotExcludeSchemas() throws IOException {
+        // A branch or workspace directory containing "readme" must not hide the schemas below it.
+        assertFalse(isExcluded("my-readme-branch/src/main/xsd/schema.xsd"));
+        assertFalse(isExcluded("readme/schema.xsd"));
+        assertFalse(isExcluded("src/main/xsd/readme-of-doom/schema.xsd"));
+    }
+
+    @Test
+    void validateReadmeSubstringInFileNameDoesNotExcludeSchemas() throws IOException {
+        assertFalse(isExcluded("src/main/xsd/my-readme-schema.xsd"));
+    }
+
+    @Test
+    void validateXmlAndTxtSuffixesAreStillExcluded() throws IOException {
+        assertTrue(isExcluded("src/main/xsd/binding.xml"));
+        assertTrue(isExcluded("src/main/xsd/notes.txt"));
+        assertFalse(isExcluded("src/main/xsd/schema.xsd"));
+    }
+
+    //
+    // Private helpers
+    //
+
+    private boolean isExcluded(final String relativePath) throws IOException {
+
+        final File toCheck = new File(projectDirectory, relativePath);
+        Files.createDirectories(toCheck.getParentFile().toPath());
+        Files.write(toCheck.toPath(), new byte[0]);
+
+        return Filters.matchAtLeastOnce(toCheck, AbstractJaxbMojo.STANDARD_EXCLUDE_FILTERS);
+    }
+}


### PR DESCRIPTION
The standard exclude patterns are matched with `.matches()` against the full canonical path of each candidate, prefixed with `PATTERN_LETTER_DIGIT_PUNCT`. That prefix admits `\p{Punct}`, which includes the file separators, so `README.*` matched any path containing "readme" anywhere — a branch or workspace directory named for a readme was enough to hide every schema below it, which is what #163 and #136 report. Compilation is `CASE_INSENSITIVE`, so the casing did not have to agree either.

Requiring a separator before `README` and forbidding one after it confines the pattern to the last path segment. The `.xml` and `.txt` entries are genuine suffix patterns and are unchanged.

The new test covers both directions: `README`/`readme.md`/`README.txt` stay excluded, while `my-readme-branch/src/main/xsd/schema.xsd`, `readme/schema.xsd` and `my-readme-schema.xsd` no longer are.

Fixes #136
Fixes #163