### PR TITLE
Stop passing -episode to XJC when generateEpisode is false

### DIFF
--- a/src/it/xjc-without-episode/pom.xml
+++ b/src/it/xjc-without-episode/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-without-episode</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Test of the xjc mojo with episode file generation switched off.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.5.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageName>com.example.myschema</packageName>
+                    <generateEpisode>false</generateEpisode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/xjc-without-episode/src/main/xsd/address.xsd
+++ b/src/it/xjc-without-episode/src/main/xsd/address.xsd
@@ -1,0 +1,16 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:complexType name="AddressType">
+    <xsd:sequence>
+      <xsd:element name="Name"   type="xsd:string"/>
+      <xsd:element name="Line1" type="xsd:string"/>
+      <xsd:element name="Line2" type="xsd:string"/>
+      <xsd:element name="City"   type="xsd:string"/>
+      <xsd:element name="State"  type="xsd:string"/>
+      <xsd:element name="ZipCode"    type="xsd:decimal"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:element name="address" type="AddressType"/>
+
+</xsd:schema>

--- a/src/it/xjc-without-episode/verify.groovy
+++ b/src/it/xjc-without-episode/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The build must complete even though no episode file was requested; before GitHub #169 XJC was
+// still handed an -episode argument pointing into a directory that had been cleared away.
+File addressTypeSource = new File( basedir, 'target/generated-sources/jaxb/com/example/myschema/AddressType.java' )
+assert addressTypeSource.exists()
+
+File addressTypeCompiled = new File( basedir, 'target/classes/com/example/myschema/AddressType.class' )
+assert addressTypeCompiled.exists()
+
+// ... and no episode file may be produced.
+File episodeDirectory = new File( basedir, 'target/generated-sources/jaxb/META-INF' )
+assert !episodeDirectory.exists(), "No META-INF should be generated when generateEpisode is false, found: " + episodeDirectory

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -636,7 +636,7 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
         builder.withNamedArgument("classpath", classPath);
 
         // We must add the -extension flag in order to generate the episode file.
-        if (!extension) {
+        if (!extension && generateEpisode) {
 
             if (getLog().isInfoEnabled()) {
                 getLog().info("Adding 'extension' flag to XJC arguments, to generate an episode "
@@ -646,8 +646,14 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
         }
         builder.withFlag(true, "extension");
 
-        final File episodeFile = getEpisodeFile(episodeFileNameOrNull);
-        builder.withNamedArgument("episode", FileSystemUtilities.getCanonicalPath(episodeFile));
+        // Only ask XJC for an episode file when one was actually requested. The episode file's parent
+        // directory is re-created after the output directory has been cleared, and only when
+        // generateEpisode is set, so handing XJC the argument regardless leaves it writing into a
+        // directory that is no longer there.
+        if (generateEpisode) {
+            final File episodeFile = getEpisodeFile(episodeFileNameOrNull);
+            builder.withNamedArgument("episode", FileSystemUtilities.getCanonicalPath(episodeFile));
+        }
 
         if (catalog != null) {
             builder.withNamedArgument("catalog", FileSystemUtilities.getCanonicalPath(catalog));


### PR DESCRIPTION
`getXjcArguments` added `-episode` unconditionally. The episode file's parent directory, meanwhile, is created while the arguments are built, then destroyed by the output-directory clear that follows, and only re-created when `generateEpisode` is set. With `generateEpisode=false` XJC was handed a path into a directory that no longer existed:

```
org.xml.sax.SAXParseException: Failed to write to .../generated-sources/jaxb/META-INF/JAXB/episode_xjc.xjb
Caused by: java.io.FileNotFoundException: ... (No such file or directory)
```

The `Created EpisodePath [...]: true` line logged immediately before comes from the argument-building step creating the directory that is then cleared away, which is why the message and the failure appear to contradict each other — @Kolarr noted exactly that in #169.

New IT `xjc-without-episode` covers it: the build has to succeed and no `META-INF` may be produced. It reproduces the original failure on unpatched code and passes with the change; the full IT suite is 42/42.

`-extension` deliberately stays unconditional. It has been passed regardless of the `extension` parameter since long before this, and narrowing it now would quietly turn extension mode off for builds that depend on it.

Fixes #169