### PR TITLE
Qualify unprefixed element references in generated schemas (#146)

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
@@ -222,6 +222,17 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
     protected boolean createJavaDocAnnotations;
 
     /**
+     * <p>If {@code true}, post-processing qualifies any unprefixed {@code <xs:element ref="..."/>} references
+     * with the prefix of the schema's target namespace. This fixes a schemagen bug where element references to
+     * elements within the target namespace are emitted without a prefix in schemas that declare no default
+     * namespace, causing downstream tools (such as XJC) to reject the schema.</p>
+     *
+     * @since 4.1.1
+     */
+    @Parameter(defaultValue = "true", property = "jaxb2.qualifyUnprefixedReferences")
+    protected boolean qualifyUnprefixedReferences = true;
+
+    /**
      * <p>A renderer used to create XML annotation text from JavaDoc comments found within the source code.
      * Unless another implementation is provided, the standard JavaDocRenderer used is
      * {@linkplain org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc.DefaultJavaDocRenderer}.</p>
@@ -442,11 +453,13 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
                 //
                 // 1. [XsdAnnotationProcessor]:            Inject JavaDoc annotations for Classes.
                 // 2. [XsdEnumerationAnnotationProcessor]: Inject JavaDoc annotations for Enums.
-                // 3. [ChangeNamespacePrefixProcessor]:    Change namespace prefixes within XSDs.
-                // 4. [ChangeFilenameProcessor]:           Change the fileNames of XSDs.
+                // 3. [QualifyTargetNamespaceReferencesProcessor]: Qualify unprefixed element references.
+                // 4. [ChangeNamespacePrefixProcessor]:    Change namespace prefixes within XSDs.
+                // 5. [ChangeFilenameProcessor]:           Change the fileNames of XSDs.
                 //
 
-                final boolean performPostProcessing = createJavaDocAnnotations || transformSchemas != null;
+                final boolean performPostProcessing =
+                        createJavaDocAnnotations || qualifyUnprefixedReferences || transformSchemas != null;
                 if (performPostProcessing) {
 
                     // Map the XML Namespaces to their respective XML URIs (and reverse)
@@ -490,6 +503,11 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
                         if (getLog().isDebugEnabled()) {
                             getLog().info("XSD post-processing: " + numProcessedFiles + " files processed.");
                         }
+                    }
+
+                    if (qualifyUnprefixedReferences) {
+                        XsdGeneratorHelper.qualifyUnprefixedElementReferences(
+                                resolverMap, getLog(), getOutputDirectory(), getEncoding(false));
                     }
 
                     if (transformSchemas != null) {

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
@@ -54,6 +54,7 @@ import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc.XsdAnnota
 import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc.XsdEnumerationAnnotationProcessor;
 import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.schemaenhancement.ChangeFilenameProcessor;
 import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.schemaenhancement.ChangeNamespacePrefixProcessor;
+import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.schemaenhancement.QualifyTargetNamespaceReferencesProcessor;
 import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.schemaenhancement.SimpleNamespaceResolver;
 import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.schemaenhancement.TransformSchema;
 import org.codehaus.mojo.jaxb2.shared.FileSystemUtilities;
@@ -61,6 +62,7 @@ import org.codehaus.mojo.jaxb2.shared.Validate;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -254,6 +256,58 @@ public final class XsdGeneratorHelper {
 
         // All done.
         return processedXSDs;
+    }
+
+    /**
+     * Qualifies any unprefixed {@code <xs:element ref="..."/>} references within generated schema files
+     * with the prefix of the schema's target namespace. This fixes an issue where schemagen generates
+     * element references without a namespace prefix for schemas that do not declare a default namespace.
+     *
+     * @param resolverMap     The map relating generated schema file name to SimpleNamespaceResolver instances.
+     * @param mavenLog        The active Log.
+     * @param schemaDirectory The directory where all generated schema files reside.
+     * @param encoding        The encoding / charset name.
+     */
+    public static void qualifyUnprefixedElementReferences(
+            final Map<String, SimpleNamespaceResolver> resolverMap,
+            final Log mavenLog,
+            final File schemaDirectory,
+            final String encoding) {
+
+        for (SimpleNamespaceResolver currentResolver : resolverMap.values()) {
+            final String targetNamespaceUri = currentResolver.getLocalNamespaceURI();
+            if (StringUtils.isEmpty(targetNamespaceUri)) {
+                continue;
+            }
+
+            final String targetNamespacePrefix =
+                    currentResolver.getNamespaceURI2PrefixMap().get(targetNamespaceUri);
+            if (StringUtils.isEmpty(targetNamespacePrefix)) {
+                continue;
+            }
+
+            final File generatedSchemaFile = new File(schemaDirectory, currentResolver.getSourceFilename());
+            final Document document = parseXmlToDocument(generatedSchemaFile, encoding);
+            final Element schemaElement = document.getDocumentElement();
+            final boolean hasDefaultNamespace = schemaElement != null
+                    && (schemaElement.hasAttribute("xmlns")
+                            || StringUtils.isNotEmpty(schemaElement.getAttribute("xmlns")));
+
+            if (!hasDefaultNamespace) {
+                final QualifyTargetNamespaceReferencesProcessor processor =
+                        new QualifyTargetNamespaceReferencesProcessor(targetNamespacePrefix, false);
+                process(document.getFirstChild(), true, processor);
+
+                if (processor.getModifiedCount() > 0) {
+                    if (mavenLog.isDebugEnabled()) {
+                        mavenLog.debug("Qualifying " + processor.getModifiedCount()
+                                + " unprefixed element reference(s) in [" + generatedSchemaFile.getName()
+                                + "] with prefix [" + targetNamespacePrefix + "].");
+                    }
+                    savePrettyPrintedDocument(document, generatedSchemaFile, encoding);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/QualifyTargetNamespaceReferencesProcessor.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/QualifyTargetNamespaceReferencesProcessor.java
@@ -1,0 +1,136 @@
+package org.codehaus.mojo.jaxb2.schemageneration.postprocessing.schemaenhancement;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.xml.XMLConstants;
+
+import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.NodeProcessor;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * <p><code>NodeProcessor</code> which prepends the target namespace prefix to any unprefixed
+ * <code>&lt;xs:element ref="..."/&gt;</code> element references within a generated XML schema document.</p>
+ *
+ * <p>Schemagen may emit unprefixed <code>ref</code> attributes when referencing elements in the target namespace
+ * without declaring a default namespace (<code>xmlns="..."</code>) on the root <code>&lt;xs:schema&gt;</code> element.
+ * According to W3C XML Schema rules, unprefixed QNames in attribute values resolve against the default namespace,
+ * so omitting both a prefix and a default namespace causes downstream validators (such as XJC) to report
+ * <code>src-resolve.4.1: Error resolving component ... It was detected that ... has no namespace</code>.
+ * This processor qualifies those references with the target namespace's prefix.</p>
+ *
+ * @author <a href="mailto:lj@jguru.se">Lennart J&ouml;relid</a>
+ * @since 4.1.1
+ */
+public class QualifyTargetNamespaceReferencesProcessor implements NodeProcessor {
+
+    // Constants
+    private static final String REFERENCE_ATTRIBUTE_NAME = "ref";
+    private static final String ELEMENT_LOCAL_NAME = "element";
+
+    // Internal state
+    private final String targetNamespacePrefix;
+    private final boolean hasDefaultNamespace;
+    private int modifiedCount = 0;
+
+    /**
+     * Creates a new QualifyTargetNamespaceReferencesProcessor.
+     *
+     * @param targetNamespacePrefix The prefix associated with the schema's targetNamespace.
+     * @param hasDefaultNamespace   <code>true</code> if the root <code>&lt;xs:schema&gt;</code> element declares
+     *                              a default namespace (i.e. <code>xmlns="..."</code>), in which case unprefixed
+     *                              QNames already legally resolve to it and must not be modified.
+     */
+    public QualifyTargetNamespaceReferencesProcessor(
+            final String targetNamespacePrefix, final boolean hasDefaultNamespace) {
+        this.targetNamespacePrefix = targetNamespacePrefix;
+        this.hasDefaultNamespace = hasDefaultNamespace;
+    }
+
+    /**
+     * @return The number of element reference nodes modified by this processor.
+     */
+    public int getModifiedCount() {
+        return modifiedCount;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean accept(final Node aNode) {
+        if (hasDefaultNamespace
+                || targetNamespacePrefix == null
+                || targetNamespacePrefix.trim().isEmpty()) {
+            return false;
+        }
+
+        if (aNode instanceof Attr) {
+            return isUnprefixedElementReference((Attr) aNode);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void process(final Node aNode) {
+        final Attr attribute = (Attr) aNode;
+        attribute.setValue(targetNamespacePrefix + ":" + attribute.getValue());
+        modifiedCount++;
+    }
+
+    //
+    // Private helpers
+    //
+
+    /**
+     * Discovers if the provided attribute is an element reference without a namespace prefix,
+     * on the form <code>&lt;xs:element ref="someElementInTargetNamespace"/&gt;</code>.
+     *
+     * @param attribute the attribute to test.
+     * @return <code>true</code> if the attribute is named "ref", has no colon in its value, and belongs to an
+     *         <code>xs:element</code> element.
+     */
+    private boolean isUnprefixedElementReference(final Attr attribute) {
+        if (!REFERENCE_ATTRIBUTE_NAME.equals(attribute.getName())
+                || attribute.getValue().contains(":")) {
+            return false;
+        }
+
+        final Element owner = attribute.getOwnerElement();
+        if (owner == null) {
+            return false;
+        }
+
+        final String localName = owner.getLocalName();
+        final String nodeName = owner.getNodeName();
+
+        final boolean isSchemaNs = XMLConstants.W3C_XML_SCHEMA_NS_URI.equals(owner.getNamespaceURI())
+                || (owner.getNamespaceURI() == null && nodeName != null && nodeName.contains("element"));
+
+        return isSchemaNs
+                && (ELEMENT_LOCAL_NAME.equalsIgnoreCase(localName)
+                        || (nodeName != null && nodeName.endsWith(":" + ELEMENT_LOCAL_NAME)));
+    }
+}

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/XsdGeneratorHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/XsdGeneratorHelperTest.java
@@ -277,6 +277,87 @@ class XsdGeneratorHelperTest {
     }
 
     @Test
+    void validateQualifyingUnprefixedElementReferences(@TempDir final File schemaDirectory) throws Exception {
+        // Assemble
+        final String namespaceUri = "http://schemas.acme.com/vehicles";
+        final String schemaXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema version=\"1.0\" targetNamespace=\"" + namespaceUri + "\"\n"
+                + "           xmlns:tns=\"" + namespaceUri + "\"\n"
+                + "           xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xs:element name=\"CarType\" type=\"tns:CarType\"/>\n"
+                + "  <xs:complexType name=\"Car\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element ref=\"CarType\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final File schemaFile = new File(schemaDirectory, "schema1.xsd");
+        Files.write(schemaFile.toPath(), schemaXml.getBytes(StandardCharsets.UTF_8));
+
+        final Map<String, SimpleNamespaceResolver> resolverMap =
+                Collections.singletonMap(schemaFile.getName(), new SimpleNamespaceResolver(schemaFile));
+
+        // Act
+        XsdGeneratorHelper.qualifyUnprefixedElementReferences(
+                resolverMap, new BufferingLog(), schemaDirectory, "UTF-8");
+
+        // Assert
+        final String processedXml = new String(Files.readAllBytes(schemaFile.toPath()), StandardCharsets.UTF_8);
+        final Element schemaElement = XsdGeneratorHelper.parseXmlStream(new StringReader(processedXml))
+                .getDocumentElement();
+
+        final Element elementWithRef = (Element) schemaElement
+                .getElementsByTagNameNS(XMLConstants.W3C_XML_SCHEMA_NS_URI, "element")
+                .item(1);
+        assertEquals("tns:CarType", elementWithRef.getAttribute("ref"));
+    }
+
+    @Test
+    void validateQualifyingAndTransformingPrefixesTogether(@TempDir final File schemaDirectory) throws Exception {
+        // Assemble
+        final String namespaceUri = "http://schemas.acme.com/vehicles";
+        final String schemaXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema version=\"1.0\" targetNamespace=\"" + namespaceUri + "\"\n"
+                + "           xmlns:tns=\"" + namespaceUri + "\"\n"
+                + "           xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xs:element name=\"CarType\" type=\"tns:CarType\"/>\n"
+                + "  <xs:complexType name=\"Car\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element ref=\"CarType\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final File schemaFile = new File(schemaDirectory, "schema1.xsd");
+        Files.write(schemaFile.toPath(), schemaXml.getBytes(StandardCharsets.UTF_8));
+
+        final Map<String, SimpleNamespaceResolver> resolverMap =
+                Collections.singletonMap(schemaFile.getName(), new SimpleNamespaceResolver(schemaFile));
+
+        final List<TransformSchema> transformSchemas =
+                Collections.singletonList(new TransformSchema(namespaceUri, "vh", null));
+
+        // Act: 1. Qualify unprefixed element refs
+        XsdGeneratorHelper.qualifyUnprefixedElementReferences(
+                resolverMap, new BufferingLog(), schemaDirectory, "UTF-8");
+
+        // Act: 2. Replace namespace prefixes
+        XsdGeneratorHelper.replaceNamespacePrefixes(
+                resolverMap, transformSchemas, new BufferingLog(), schemaDirectory, "UTF-8");
+
+        // Assert
+        final String processedXml = new String(Files.readAllBytes(schemaFile.toPath()), StandardCharsets.UTF_8);
+        final Element schemaElement = XsdGeneratorHelper.parseXmlStream(new StringReader(processedXml))
+                .getDocumentElement();
+
+        final Element elementWithRef = (Element) schemaElement
+                .getElementsByTagNameNS(XMLConstants.W3C_XML_SCHEMA_NS_URI, "element")
+                .item(1);
+        assertEquals("vh:CarType", elementWithRef.getAttribute("ref"));
+    }
+
+    @Test
     void validateProcessingXSDsWithEnumerations() throws Exception {
 
         // Assemble

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/QualifyTargetNamespaceReferencesProcessorTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/schemaenhancement/QualifyTargetNamespaceReferencesProcessorTest.java
@@ -1,0 +1,155 @@
+package org.codehaus.mojo.jaxb2.schemageneration.postprocessing.schemaenhancement;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.StringReader;
+import java.util.List;
+
+import org.codehaus.mojo.jaxb2.schemageneration.XsdGeneratorHelper;
+import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.DebugNodeProcessor;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QualifyTargetNamespaceReferencesProcessorTest {
+
+    @Test
+    void validateUnprefixedElementReferenceIsPrefixedWhenNoDefaultNamespace() {
+        // Assemble
+        final String prefix = "tns";
+        final String xmlStream = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema version=\"1.0\"\n"
+                + "           targetNamespace=\"http://schemas.acme.com/vehicles\"\n"
+                + "           xmlns:tns=\"http://schemas.acme.com/vehicles\"\n"
+                + "           xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xs:element name=\"CarType\" type=\"tns:CarType\"/>\n"
+                + "  <xs:complexType name=\"Car\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element ref=\"CarType\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final QualifyTargetNamespaceReferencesProcessor unitUnderTest =
+                new QualifyTargetNamespaceReferencesProcessor(prefix, false);
+        final DebugNodeProcessor debugNodeProcessor = new DebugNodeProcessor(unitUnderTest);
+
+        // Act
+        final Document document = XsdGeneratorHelper.parseXmlStream(new StringReader(xmlStream));
+        XsdGeneratorHelper.process(document.getFirstChild(), true, debugNodeProcessor);
+
+        // Assert
+        final List<Node> acceptedNodes = debugNodeProcessor.getAcceptedNodes();
+        assertEquals(1, acceptedNodes.size());
+        assertEquals(1, unitUnderTest.getModifiedCount());
+        Node elementReferenceAttribute = acceptedNodes.get(0);
+        assertEquals("ref", elementReferenceAttribute.getNodeName());
+        assertEquals("tns:CarType", elementReferenceAttribute.getNodeValue());
+    }
+
+    @Test
+    void validateUnprefixedElementReferenceNotModifiedWhenDefaultNamespacePresent() {
+        // Assemble: schema has xmlns="http://schemas.acme.com/vehicles"
+        final String prefix = "tns";
+        final String xmlStream = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema version=\"1.0\"\n"
+                + "           targetNamespace=\"http://schemas.acme.com/vehicles\"\n"
+                + "           xmlns=\"http://schemas.acme.com/vehicles\"\n"
+                + "           xmlns:tns=\"http://schemas.acme.com/vehicles\"\n"
+                + "           xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xs:complexType name=\"Car\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element ref=\"CarType\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final QualifyTargetNamespaceReferencesProcessor unitUnderTest =
+                new QualifyTargetNamespaceReferencesProcessor(prefix, true);
+        final DebugNodeProcessor debugNodeProcessor = new DebugNodeProcessor(unitUnderTest);
+
+        // Act
+        final Document document = XsdGeneratorHelper.parseXmlStream(new StringReader(xmlStream));
+        XsdGeneratorHelper.process(document.getFirstChild(), true, debugNodeProcessor);
+
+        // Assert
+        assertTrue(debugNodeProcessor.getAcceptedNodes().isEmpty());
+        assertEquals(0, unitUnderTest.getModifiedCount());
+    }
+
+    @Test
+    void validateAlreadyPrefixedElementReferenceNotModified() {
+        // Assemble
+        final String prefix = "tns";
+        final String xmlStream = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema version=\"1.0\"\n"
+                + "           targetNamespace=\"http://schemas.acme.com/vehicles\"\n"
+                + "           xmlns:other=\"http://schemas.acme.com/other\"\n"
+                + "           xmlns:tns=\"http://schemas.acme.com/vehicles\"\n"
+                + "           xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xs:complexType name=\"Car\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element ref=\"other:CarType\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final QualifyTargetNamespaceReferencesProcessor unitUnderTest =
+                new QualifyTargetNamespaceReferencesProcessor(prefix, false);
+        final DebugNodeProcessor debugNodeProcessor = new DebugNodeProcessor(unitUnderTest);
+
+        // Act
+        final Document document = XsdGeneratorHelper.parseXmlStream(new StringReader(xmlStream));
+        XsdGeneratorHelper.process(document.getFirstChild(), true, debugNodeProcessor);
+
+        // Assert
+        assertTrue(debugNodeProcessor.getAcceptedNodes().isEmpty());
+        assertEquals(0, unitUnderTest.getModifiedCount());
+    }
+
+    @Test
+    void validateNullOrEmptyPrefixDoesNotModifyNodes() {
+        // Assemble
+        final String xmlStream = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema version=\"1.0\"\n"
+                + "           xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xs:complexType name=\"Car\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element ref=\"CarType\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final QualifyTargetNamespaceReferencesProcessor unitUnderTest =
+                new QualifyTargetNamespaceReferencesProcessor(null, false);
+        final DebugNodeProcessor debugNodeProcessor = new DebugNodeProcessor(unitUnderTest);
+
+        // Act
+        final Document document = XsdGeneratorHelper.parseXmlStream(new StringReader(xmlStream));
+        XsdGeneratorHelper.process(document.getFirstChild(), true, debugNodeProcessor);
+
+        // Assert
+        assertTrue(debugNodeProcessor.getAcceptedNodes().isEmpty());
+        assertEquals(0, unitUnderTest.getModifiedCount());
+    }
+}


### PR DESCRIPTION
When `schemagen` generates schemas with a `targetNamespace` but without a default namespace declaration (`xmlns="..."`), element references (`<xs:element ref="..."/>`) to elements within the target namespace are emitted without a prefix.

According to W3C XML Schema rules, unprefixed QNames in attribute values resolve against the default namespace (`xmlns`). When a schema defines a `targetNamespace` without a default namespace, omitting both prefix and default namespace makes the reference unresolvable, causing downstream tools (such as XJC) to fail:
```
src-resolve.4.1: Error resolving component '...'. It was detected that '...' has no namespace, but components with no target namespace are not referenceable from schema document ...
```

### Context & Superseding PR #363
PR #363 previously bundled three changes:
1. Retaining namespace declaration when `toPrefix` equals the current prefix (extracted and merged in #409).
2. Order-independent canonical prefix resolution in `SimpleNamespaceResolver` (extracted and merged in #410).
3. The remaining piece: prefixing element references.

However, #363 placed this logic inside `ChangeNamespacePrefixProcessor`, which had several limitations:
- **Coupled to `<transformSchemas>`:** The fix only activated if `<transformSchemas>` was configured with `<toPrefix>`, leaving standard `schemagen` runs unfixed. (And after #409, setting `toPrefix="tns"` became a no-op).
- **Hardcoded prefix `"tns"`:** It only checked `oldPrefix.equals("tns")`, skipping schemas where the target namespace used a custom prefix declared via `@XmlSchema(xmlns=...)`.
- **SRP violation:** It conflated prefix renaming with schema reference qualification.

### Solution
- Introduced `QualifyTargetNamespaceReferencesProcessor`, a dedicated `NodeProcessor` that qualifies unprefixed `<xs:element ref="...">` attributes with the schema's target namespace prefix.
- Checks if the root `<xs:schema>` declares a default namespace (`xmlns="..."`); if so, references are legally bound to it and left untouched.
- Runs on all generated schemas during Mojo post-processing, dynamically reading the target namespace prefix from `SimpleNamespaceResolver`.
- Executes **before** `replaceNamespacePrefixes`, ensuring that subsequent `<transformSchemas>` renames (e.g. `tns` -> `vh`) seamlessly update both definitions and newly qualified references.
- Added `@Parameter(defaultValue = "true", property = "jaxb2.qualifyUnprefixedReferences") protected boolean qualifyUnprefixedReferences = true;` to `AbstractXsdGeneratorMojo`.
- Added comprehensive unit tests and verified against full unit test suite and integration tests.

Fixes #146.
Supersedes #363.