### PR TITLE
Clean up XjcLogAdapter logging and message formatting (#121, #159)

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapter.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapter.java
@@ -74,7 +74,7 @@ public class XjcLogAdapter extends XJCListener {
      */
     @Override
     public void error(final SAXParseException exception) {
-        log.error(getLocation(exception), exception);
+        log.error(formatMessage(exception), exception);
     }
 
     /**
@@ -82,7 +82,7 @@ public class XjcLogAdapter extends XJCListener {
      */
     @Override
     public void fatalError(final SAXParseException exception) {
-        log.error(getLocation(exception), exception);
+        log.error(formatMessage(exception), exception);
     }
 
     /**
@@ -90,7 +90,12 @@ public class XjcLogAdapter extends XJCListener {
      */
     @Override
     public void warning(final SAXParseException exception) {
-        log.warn(getLocation(exception), exception);
+        final String message = formatMessage(exception);
+        if (log.isDebugEnabled()) {
+            log.warn(message, exception);
+        } else {
+            log.warn(message);
+        }
     }
 
     /**
@@ -98,16 +103,28 @@ public class XjcLogAdapter extends XJCListener {
      */
     @Override
     public void info(final SAXParseException exception) {
-        log.info(getLocation(exception), exception);
+        final String message = formatMessage(exception);
+        if (log.isDebugEnabled()) {
+            log.info(message, exception);
+        } else {
+            log.info(message);
+        }
     }
 
     //
     // Private helpers
     //
 
-    private String getLocation(final SAXParseException e) {
+    private String formatMessage(final SAXParseException e) {
+        final String location = getLocation(e);
+        return (location == null ? "" : location) + e.getMessage();
+    }
 
+    private String getLocation(final SAXParseException e) {
         final String exceptionId = e.getPublicId() == null ? e.getSystemId() : e.getPublicId();
-        return exceptionId + " [" + e.getLineNumber() + "," + e.getColumnNumber() + "] ";
+        if (exceptionId == null && e.getLineNumber() <= 0 && e.getColumnNumber() <= 0) {
+            return null;
+        }
+        return (exceptionId == null ? "" : exceptionId) + " [" + e.getLineNumber() + "," + e.getColumnNumber() + "] ";
     }
 }

--- a/src/test/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapterTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/javageneration/XjcLogAdapterTest.java
@@ -1,0 +1,93 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+
+import org.codehaus.mojo.jaxb2.BufferingLog;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class XjcLogAdapterTest {
+
+    @Test
+    void validateInfoDoesNotPassThrowableWhenDebugDisabled() {
+        // Assemble
+        final BufferingLog log = new BufferingLog(BufferingLog.LogLevel.INFO);
+        final XjcLogAdapter unitUnderTest = new XjcLogAdapter(log);
+        final SAXParseException exception = new SAXParseException("generating code", null);
+
+        // Act
+        unitUnderTest.info(exception);
+
+        // Assert
+        final Map<String, Throwable> entries = log.getLogBuffer();
+        assertEquals(1, entries.size());
+
+        final Map.Entry<String, Throwable> entry = entries.entrySet().iterator().next();
+        assertNull(entry.getValue(), "Info log must not pass Throwable when debug is disabled");
+        assertTrue(entry.getKey().contains("generating code"));
+        assertFalse(entry.getKey().contains("null [-1,-1]"), "Must not output 'null [-1,-1]' prefix");
+    }
+
+    @Test
+    void validateInfoPassesThrowableWhenDebugEnabled() {
+        // Assemble
+        final BufferingLog log = new BufferingLog(BufferingLog.LogLevel.DEBUG);
+        final XjcLogAdapter unitUnderTest = new XjcLogAdapter(log);
+        final SAXParseException exception = new SAXParseException("generating code", null);
+
+        // Act
+        unitUnderTest.info(exception);
+
+        // Assert
+        final Map<String, Throwable> entries = log.getLogBuffer();
+        assertEquals(1, entries.size());
+
+        final Map.Entry<String, Throwable> entry = entries.entrySet().iterator().next();
+        assertNotNull(entry.getValue(), "Info log should pass Throwable when debug is enabled");
+        assertTrue(entry.getKey().contains("generating code"));
+    }
+
+    @Test
+    void validateWarningFormatsLocationAndOmitsThrowableWhenDebugDisabled() {
+        // Assemble
+        final BufferingLog log = new BufferingLog(BufferingLog.LogLevel.WARN);
+        final XjcLogAdapter unitUnderTest = new XjcLogAdapter(log);
+        final SAXParseException exception = new SAXParseException("Unused type", "publicId", "systemId.xsd", 10, 5);
+
+        // Act
+        unitUnderTest.warning(exception);
+
+        // Assert
+        final Map<String, Throwable> entries = log.getLogBuffer();
+        assertEquals(1, entries.size());
+
+        final Map.Entry<String, Throwable> entry = entries.entrySet().iterator().next();
+        assertNull(entry.getValue(), "Warning log must not pass Throwable when debug is disabled");
+        assertTrue(entry.getKey().contains("publicId [10,5] Unused type"));
+    }
+}


### PR DESCRIPTION
## Description
This PR resolves #121 and #159 by cleaning up log emission from `XjcLogAdapter`:

1. **Include exception message in log output**: `formatMessage(exception)` now formats both the location (when known) and `exception.getMessage()`. Previously, `getLocation(exception)` only produced the location string, causing the actual message to only appear inside the stack trace.
2. **Suppress stack trace spam for `warning` and `info`**: `warning()` and `info()` no longer log full `Throwable` stack traces unless debug logging is enabled (`log.isDebugEnabled()`). This prevents normal schema warnings and informational messages from spamming the build console. Full stack traces are preserved for `error()` and `fatalError()`.
3. **Avoid awkward `null [-1,-1]` prefixes**: When neither publicId nor systemId is known, and line/column numbers are <= 0, `getLocation()` returns `null` rather than emitting `"null [-1,-1] "`.

## Fixes
Fixes #121
Fixes #159

## Verification
- Added comprehensive unit tests in `XjcLogAdapterTest.java` verifying formatted messages, null location suppression, and debug vs non-debug logging behavior.
- All unit and integration tests pass cleanly (`mvn test`).