### PR TITLE
Clear output directory before resolving episode file to avoid suffix accumulation (#300)

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -481,17 +481,12 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
                 // Setup the environment.
                 environment.setup();
 
-                // Compile the XJC arguments
-                final String[] xjcArguments = getXjcArguments(environment.getClassPathAsArgument(), episodeFileName);
-
-                // Ensure that the outputDirectory exists, but only clear it if does not already
+                // Ensure that the outputDirectory exists and is cleared before compiling arguments
+                // so that episode file calculation operates on a clean directory.
                 FileSystemUtilities.createDirectory(getOutputDirectory(), clearOutputDir);
 
-                // Do we need to re-create the episode file's parent directory.
-                final boolean reCreateEpisodeFileParentDirectory = generateEpisode && clearOutputDir;
-                if (reCreateEpisodeFileParentDirectory) {
-                    getEpisodeFile(episodeFileName);
-                }
+                // Compile the XJC arguments
+                final String[] xjcArguments = getXjcArguments(environment.getClassPathAsArgument(), episodeFileName);
 
                 // Check the system properties.
                 logSystemPropertiesAndBasedir();

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
@@ -390,25 +390,16 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
             // Setup the environment.
             environment.setup();
 
+            // Ensure that the outputDirectory and workDirectory exist and are cleared
+            // before compiling arguments so that episode file calculation operates on a clean directory.
+            FileSystemUtilities.createDirectory(getOutputDirectory(), clearOutputDir);
+            FileSystemUtilities.createDirectory(getWorkDirectory(), clearOutputDir);
+
             // Compile the SchemaGen arguments
             final File episodeFile = getEpisodeFile(episodeFileName);
             final List<URL> sources = getSources();
             final String[] schemaGenArguments =
                     getSchemaGenArguments(environment.getClassPathAsArgument(), episodeFile, sources);
-
-            // Ensure that the outputDirectory and workDirectory exists.
-            // Clear them if configured to do so.
-            FileSystemUtilities.createDirectory(getOutputDirectory(), clearOutputDir);
-            FileSystemUtilities.createDirectory(getWorkDirectory(), clearOutputDir);
-
-            // Re-generate the episode file's parent directory.
-            getEpisodeFile(episodeFileName);
-            // Do we need to re-create the episode file's parent directory?
-            /*final boolean reCreateEpisodeFileParentDirectory = generateEpisode && clearOutputDir;
-            if (reCreateEpisodeFileParentDirectory) {
-
-            }
-            */
 
             try {
 

--- a/src/test/java/org/codehaus/mojo/jaxb2/EpisodeFileTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/EpisodeFileTest.java
@@ -1,0 +1,117 @@
+package org.codehaus.mojo.jaxb2;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.mojo.jaxb2.shared.FileSystemUtilities;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EpisodeFileTest {
+
+    private static class ConcreteJaxbMojo extends AbstractJaxbMojo {
+        private File outputDirectory;
+
+        void setOutputDirectory(final File outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        @Override
+        protected File getOutputDirectory() {
+            return outputDirectory;
+        }
+
+        @Override
+        protected boolean isReGenerationRequired() {
+            return false;
+        }
+
+        @Override
+        protected boolean performExecution() throws MojoExecutionException, MojoFailureException {
+            return false;
+        }
+
+        @Override
+        protected String getStaleFileName() {
+            return "stale";
+        }
+
+        @Override
+        protected void addGeneratedSourcesToProjectSourceRoot(final String canonicalPathToOutputDirectory) {}
+
+        @Override
+        protected boolean shouldExecutionBeSkipped() {
+            return false;
+        }
+
+        @Override
+        protected List<String> getClasspath() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected List<URL> getSources() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected void addResource(final Resource resource) {}
+    }
+
+    private ConcreteJaxbMojo mojo;
+
+    @BeforeEach
+    void setUp() {
+        mojo = new ConcreteJaxbMojo();
+        mojo.setLog(new BufferingLog());
+    }
+
+    @Test
+    void validateEpisodeFileNameWhenDirectoryClearedBeforehand(@TempDir final File tempDir) throws Exception {
+        final File outputDir = new File(tempDir, "output");
+        assertTrue(outputDir.mkdirs());
+        mojo.setOutputDirectory(outputDir);
+
+        // First run generates base name
+        final File episode1 = mojo.getEpisodeFile(null);
+        assertEquals("sun-jaxb.episode.xjb", episode1.getName());
+        assertTrue(episode1.createNewFile());
+
+        // Without clearing output directory, subsequent run increments suffix
+        final File episode2WithoutClear = mojo.getEpisodeFile(null);
+        assertEquals("sun-jaxb.episode_1.xjb", episode2WithoutClear.getName());
+
+        // With clearing before getEpisodeFile (fix for #300), base name is consistently maintained
+        FileSystemUtilities.createDirectory(outputDir, true);
+        final File episodeAfterClear = mojo.getEpisodeFile(null);
+        assertEquals("sun-jaxb.episode.xjb", episodeAfterClear.getName());
+    }
+}


### PR DESCRIPTION
## Description
This PR resolves #300 where subsequent builds without a `mvn clean` caused the generated episode file name to accumulate numbered suffixes indefinitely (e.g. `sun-jaxb.episode.xjb`, `sun-jaxb.episode_1.xjb`, `sun-jaxb.episode_2.xjb`, ...).

### Cause
In both `AbstractJavaGeneratorMojo.performExecution()` and `AbstractXsdGeneratorMojo.performExecution()`, arguments were compiled—and `getEpisodeFile()` was called—**before** `outputDirectory` was cleared with `FileSystemUtilities.createDirectory(outputDirectory, clearOutputDir)`.

When `getEpisodeFile()` was called:
1. It inspected `outputDirectory/META-INF/JAXB` for existing files matching the episode filename pattern.
2. Because the output directory had not yet been cleaned, the episode file from the previous build still existed on disk, so `getEpisodeFile()` picked the next incremented suffix (`_1.xjb`, `_2.xjb`, etc.) and passed it to XJC / SchemaGen CLI arguments.
3. Immediately afterwards, `createDirectory(..., clearOutputDir)` wiped `outputDirectory`.
4. Then a redundant second call to `getEpisodeFile()` was made to re-create the parent directory.

### Solution
1. Moved directory clearing (`FileSystemUtilities.createDirectory(...)`) to execute **before** compiling tool arguments / resolving the episode file.
2. Removed the redundant duplicate call to `getEpisodeFile()`.
3. When `getEpisodeFile()` is called, the output directory is already clean, so it consistently produces the canonical base episode filename (`sun-jaxb.episode.xjb`) on every build without incrementing suffixes.

## Fixes
Fixes #300

## Verification
- Added `EpisodeFileTest.validateEpisodeFileNameWhenDirectoryClearedBeforehand`: verifies that without clearing, suffixes increment, but clearing before `getEpisodeFile()` ensures consistent base filename reuse across runs.
- All unit and integration tests pass cleanly (`mvn test`).