### PR TITLE
Add configuration option for -XautoNameResolution (#185)

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -280,6 +280,16 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
     private boolean enableIntrospection;
 
     /**
+     * <p>Corresponding XJC parameter: {@code -XautoNameResolution}.</p>
+     * <p>By default, the XJC binding compiler fails when name collisions occur.
+     * Use this option to enable automatic name conflict resolution.</p>
+     *
+     * @since 4.1.1
+     */
+    @Parameter(property = "xjc.autoNameResolution", defaultValue = "false")
+    protected boolean autoNameResolution;
+
+    /**
      * <p>Corresponding XJC parameter: {@code p}.</p>
      * <p>The package under which the source files will be generated. Quoting the XJC documentation:
      * "Specifying a target package via this command-line option overrides any binding customization for package
@@ -609,7 +619,7 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
     // Private helpers
     //
 
-    private String[] getXjcArguments(final String classPath, final String episodeFileNameOrNull)
+    protected String[] getXjcArguments(final String classPath, final String episodeFileNameOrNull)
             throws MojoExecutionException, NoSchemasException {
 
         final ArgumentBuilder builder = new ArgumentBuilder();
@@ -625,10 +635,11 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
         builder.withFlag(readOnly, "readOnly");
         builder.withFlag(noGeneratedHeaderComments, "no-header");
         builder.withFlag(addGeneratedAnnotation, "mark-generated");
+        builder.withFlag(autoNameResolution, "XautoNameResolution");
 
         // Add all arguments on the form '-argumentName argumentValue'
         // (i.e. in 2 separate elements of the returned String[])
-        builder.withNamedArgument("httpproxy", getProxyString(settings.getActiveProxy()));
+        builder.withNamedArgument("httpproxy", getProxyString(settings == null ? null : settings.getActiveProxy()));
         builder.withNamedArgument("encoding", getEncoding(true));
         builder.withNamedArgument("p", packageName);
         builder.withNamedArgument("target", target);

--- a/src/test/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojoTest.java
@@ -1,0 +1,138 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.settings.Settings;
+import org.codehaus.mojo.jaxb2.BufferingLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractJavaGeneratorMojoTest {
+
+    private static class TestableJavaGeneratorMojo extends AbstractJavaGeneratorMojo {
+        private File outputDirectory;
+        private List<URL> sources = Collections.emptyList();
+        private List<File> xjbFiles = Collections.emptyList();
+
+        TestableJavaGeneratorMojo() {
+            this.sourceType = SourceContentType.XmlSchema;
+            this.settings = new Settings();
+        }
+
+        void setOutputDirectory(final File outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        void setSources(final List<URL> sources) {
+            this.sources = sources;
+        }
+
+        void setSourceXJBs(final List<File> xjbFiles) {
+            this.xjbFiles = xjbFiles;
+        }
+
+        @Override
+        protected List<URL> getSources() {
+            return sources;
+        }
+
+        @Override
+        protected List<File> getSourceXJBs() {
+            return xjbFiles;
+        }
+
+        @Override
+        protected String getStaleFileName() {
+            return "staleFlag";
+        }
+
+        @Override
+        protected File getOutputDirectory() {
+            return outputDirectory;
+        }
+
+        @Override
+        protected void addGeneratedSourcesToProjectSourceRoot(final String canonicalPathToOutputDirectory) {}
+
+        @Override
+        protected boolean shouldExecutionBeSkipped() {
+            return false;
+        }
+
+        @Override
+        protected List<String> getClasspath() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected void addResource(final Resource resource) {}
+
+        @Override
+        protected boolean isReGenerationRequired() {
+            return false;
+        }
+    }
+
+    private TestableJavaGeneratorMojo mojo;
+
+    @BeforeEach
+    void setUp(@TempDir final File tempDir) throws Exception {
+        mojo = new TestableJavaGeneratorMojo();
+        mojo.setLog(new BufferingLog(BufferingLog.LogLevel.DEBUG));
+        mojo.setOutputDirectory(new File(tempDir, "output"));
+        final File fakeSchema = new File(tempDir, "schema.xsd");
+        assertTrue(fakeSchema.createNewFile());
+        mojo.setSources(Collections.singletonList(fakeSchema.toURI().toURL()));
+    }
+
+    @Test
+    void validateAutoNameResolutionFalseByDefault() {
+        assertFalse(mojo.autoNameResolution);
+    }
+
+    @Test
+    void validateAutoNameResolutionNotAddedWhenFalse() throws Exception {
+        mojo.autoNameResolution = false;
+
+        final List<String> arguments = Arrays.asList(mojo.getXjcArguments("target/classes", null));
+
+        assertFalse(arguments.contains("-XautoNameResolution"));
+    }
+
+    @Test
+    void validateAutoNameResolutionAddedWhenTrue() throws Exception {
+        mojo.autoNameResolution = true;
+
+        final List<String> arguments = Arrays.asList(mojo.getXjcArguments("target/classes", null));
+
+        assertTrue(arguments.contains("-XautoNameResolution"));
+    }
+}


### PR DESCRIPTION
### Summary of Changes

Resolves #185 by introducing a new configuration option `autoNameResolution` (with property `xjc.autoNameResolution`, default `false`) in `AbstractJavaGeneratorMojo`. When enabled, the `-XautoNameResolution` flag is passed to the underlying XJC compiler.

### Rationale & Guidance

The `<arguments/>` parameter was deprecated in favor of dedicated plugin configuration properties. However, XJC's `-XautoNameResolution` flag (used for automatic name conflict resolution when schemas contain conflicting element/type declarations) lacked a corresponding first-class parameter.

With this change:
- Users can enable automatic name conflict resolution directly in plugin configuration:
  ```xml
  <configuration>
      <autoNameResolution>true</autoNameResolution>
  </configuration>
  ```
- Or via property from the command line:
  `-Dxjc.autoNameResolution=true`

### Testing & Verification
- Added unit tests in `AbstractJavaGeneratorMojoTest`:
  - `validateAutoNameResolutionFalseByDefault`: verifies default value is `false`.
  - `validateAutoNameResolutionNotAddedWhenFalse`: verifies `-XautoNameResolution` is not added to arguments when disabled.
  - `validateAutoNameResolutionAddedWhenTrue`: verifies `-XautoNameResolution` is passed to XJC arguments when enabled.
- Verified that all unit tests pass (`mvn test`).
- Verified code formatting with `mvn spotless:check`.