### PR TITLE
Fix missing JavaDoc annotations when class name contains underscore (#93)

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/DomHelper.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/DomHelper.java
@@ -230,7 +230,7 @@ public final class DomHelper {
                     final String effectiveClassName = current.getAnnotationRenamedTo() == null
                             ? current.getClassName()
                             : current.getAnnotationRenamedTo();
-                    if (effectiveClassName.equalsIgnoreCase(nodeClassName)) {
+                    if (matchesClassName(effectiveClassName, nodeClassName)) {
                         return current;
                     }
                 }
@@ -239,6 +239,36 @@ public final class DomHelper {
 
         // Nothing found
         return null;
+    }
+
+    /**
+     * Checks if a Java class name matches a schema type name, taking into account
+     * JAXB's standard Java identifier to XML type name mapping (e.g. converting
+     * "DummyRequest_v1" to "dummyRequestV1").
+     *
+     * @param javaClassName  The Java class name or effective annotated XML type name.
+     * @param schemaTypeName The XML schema type name from the DOM node.
+     * @return {@code true} if the names match, {@code false} otherwise.
+     */
+    public static boolean matchesClassName(final String javaClassName, final String schemaTypeName) {
+        if (javaClassName == null || schemaTypeName == null) {
+            return false;
+        }
+        if (javaClassName.equalsIgnoreCase(schemaTypeName)) {
+            return true;
+        }
+        // JAXB maps Java class identifiers to XML type names via NameConverter.standard.toVariableName(className),
+        // which removes underscores and camelCases words (e.g. "DummyRequest_v1" becomes "dummyRequestV1").
+        try {
+            if (org.glassfish.jaxb.core.api.impl.NameConverter.standard
+                    .toVariableName(javaClassName)
+                    .equalsIgnoreCase(schemaTypeName)) {
+                return true;
+            }
+        } catch (Throwable ignored) {
+            // Fallback if NameConverter is not accessible
+        }
+        return javaClassName.replace("_", "").equalsIgnoreCase(schemaTypeName.replace("_", ""));
     }
 
     /**
@@ -351,7 +381,7 @@ public final class DomHelper {
                             ? DomHelper.getValueAttribute(aNode)
                             : DomHelper.getNameAttribute(aNode);
                     if (fieldName.equalsIgnoreCase(attributeValue)
-                            && className.equalsIgnoreCase(DomHelper.getNameAttribute(containingClassNode))) {
+                            && matchesClassName(className, DomHelper.getNameAttribute(containingClassNode))) {
                         toReturn = (T) current;
                     }
                 } catch (Exception e) {

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/DomHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/DomHelperTest.java
@@ -8,6 +8,8 @@ import java.util.TreeMap;
 
 import org.codehaus.mojo.jaxb2.PropertyResources;
 import org.codehaus.mojo.jaxb2.schemageneration.XsdGeneratorHelper;
+import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc.location.ClassLocation;
+import org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc.location.FieldLocation;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -15,7 +17,9 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="mailto:lj@jguru.se">Lennart J&ouml;relid</a>, jGuru Europe AB
@@ -61,6 +65,43 @@ class DomHelperTest {
         assertEquals("LACTO_VEGETARIAN", xpath2ValueMap.get(prefix + "LACTO_VEGETARIAN']"));
         assertEquals("NONE", xpath2ValueMap.get(prefix + "NONE']"));
         assertEquals("VEGAN", xpath2ValueMap.get(prefix + "VEGAN']"));
+    }
+
+    @Test
+    void validateMatchesClassNameWithUnderscore() {
+        assertTrue(DomHelper.matchesClassName("DummyRequest_v1", "dummyRequestV1"));
+        assertTrue(DomHelper.matchesClassName("SomewhatNamedPerson", "somewhatNamedPerson"));
+        assertTrue(DomHelper.matchesClassName("DummyRequest_v1", "dummyRequest_v1"));
+        assertTrue(DomHelper.matchesClassName("Order_Item_Detail", "orderItemDetail"));
+        assertFalse(DomHelper.matchesClassName("DummyRequest_v1", "otherType"));
+    }
+
+    @Test
+    void validateGetClassLocationAndFieldLocationWithUnderscore() throws Exception {
+        final String xsd = "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                + "  <xs:complexType name=\"dummyRequestV1\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element name=\"requestData\" type=\"xs:string\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>";
+        final Document document = XsdGeneratorHelper.parseXmlStream(new StringReader(xsd));
+        final Element schemaElement = document.getDocumentElement();
+        final Element complexType = getChildOf(schemaElement, "complexType", "dummyRequestV1");
+        assertNotNull(complexType);
+        final Element sequence = getChildOf(complexType, "sequence", null);
+        assertNotNull(sequence);
+        final Element element = getChildOf(sequence, "element", "requestData");
+        assertNotNull(element);
+
+        final ClassLocation classLocation = new ClassLocation("com.example", "DummyRequest_v1", null);
+        final FieldLocation fieldLocation =
+                new FieldLocation("com.example", "DummyRequest_v1", null, "requestData", null);
+
+        assertEquals(
+                classLocation, DomHelper.getClassLocation(complexType, java.util.Collections.singleton(classLocation)));
+        assertEquals(
+                fieldLocation, DomHelper.getFieldLocation(element, java.util.Collections.singleton(fieldLocation)));
     }
 
     //

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/DummyRequest_v1.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/DummyRequest_v1.java
@@ -1,0 +1,53 @@
+package org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+/**
+ * Class documentation for DummyRequest_v1.
+ */
+@XmlRootElement
+@XmlType(namespace = DummyRequest_v1.NAMESPACE)
+@XmlAccessorType(XmlAccessType.FIELD)
+public class DummyRequest_v1 {
+
+    public static final String NAMESPACE = "http://example.com/dummy";
+
+    /**
+     * Field documentation for requestData.
+     */
+    @XmlElement(required = true)
+    private String requestData;
+
+    public DummyRequest_v1() {}
+
+    public DummyRequest_v1(final String requestData) {
+        this.requestData = requestData;
+    }
+
+    public String getRequestData() {
+        return requestData;
+    }
+}

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/XsdAnnotationProcessorWithUnderscoreTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/XsdAnnotationProcessorWithUnderscoreTest.java
@@ -1,0 +1,57 @@
+package org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class XsdAnnotationProcessorWithUnderscoreTest extends AbstractSourceCodeAwareNodeProcessingTest {
+
+    private JavaDocRenderer renderer = new DefaultJavaDocRenderer();
+
+    @Test
+    void validateProcessingClassNameWithUnderscore() throws Exception {
+        final Document document = namespace2DocumentMap.get(DummyRequest_v1.NAMESPACE);
+        final Node rootNode = document.getFirstChild();
+
+        final XsdAnnotationProcessor unitUnderTest = new XsdAnnotationProcessor(docs, renderer);
+
+        // Act
+        process(rootNode, true, unitUnderTest);
+
+        // Assert
+        final String processed = printDocument(document);
+
+        // Verify that both class-level and field-level documentation annotations are present
+        assertTrue(processed.contains("Class documentation for DummyRequest_v1."));
+        assertTrue(processed.contains("Field documentation for requestData."));
+    }
+
+    @Override
+    protected List<Class<?>> getJaxbAnnotatedClassesForJaxbContext() {
+        return Collections.<Class<?>>singletonList(DummyRequest_v1.class);
+    }
+}


### PR DESCRIPTION
### Summary of Changes

Fixes #93 by updating `DomHelper` to match Java class names to XML schema type names taking into account JAXB's standard Java-identifier-to-variable-name mapping (which strips underscores and camelCases words).

### Problem & Rationale

When running `schemagen`, JAXB generates default XML schema type names using `NameConverter.standard.toVariableName(className)` (JSR-222 Appendix D.2).
- For class `DummyRequest_v1`, JAXB emits `<xs:complexType name="dummyRequestV1">` in the generated schema.
- Previously, `DomHelper.getClassLocation` and `DomHelper.getFieldOrMethodLocationIfValid` only compared the Java class name `"DummyRequest_v1"` directly to the schema node name `"dummyRequestV1"` via `equalsIgnoreCase()`.
- Because `"DummyRequest_v1".equalsIgnoreCase("dummyRequestV1")` evaluates to `false`, `XsdAnnotationProcessor` rejected both the complexType node and its child element/attribute nodes, causing all class-level and member-level JavaDoc annotations to be omitted from the generated XSD.

### Solution

1. Added `DomHelper.matchesClassName(javaClassName, schemaTypeName)`:
   - Matches if identical (case-insensitive)
   - Matches via `NameConverter.standard.toVariableName(javaClassName)` (matching JAXB's mapping of `DummyRequest_v1` -> `dummyRequestV1`)
   - Fallback comparison stripping underscores (`replace("_", "")`)
2. Used `matchesClassName()` in:
   - `DomHelper.getClassLocation()` for class-level type matching
   - `DomHelper.getFieldOrMethodLocationIfValid()` for member-level type matching against `containingClassNode`
3. Added unit tests:
   - `DomHelperTest.validateMatchesClassNameWithUnderscore`: unit test verifying name matching.
   - `DomHelperTest.validateGetClassLocationAndFieldLocationWithUnderscore`: verifying `ClassLocation` and `FieldLocation` extraction from DOM with underscores.
   - `XsdAnnotationProcessorWithUnderscoreTest`: full end-to-end schema post-processing test with a class named `DummyRequest_v1` verifying that both class and field JavaDoc annotations are successfully injected into the resulting XSD.

### Testing & Verification
- Ran unit tests: All 122 tests passed (`mvn test`).
- Ran Spotless formatting check: Passed clean (`mvn spotless:check`).