### PR TITLE
Fix #160: Avoid empty lines in schemagen generated XSDs on JDK 9+

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/XsdGeneratorHelper.java
@@ -515,7 +515,13 @@ public final class XsdGeneratorHelper {
      * @param node The Node whose children should be converted to a String.
      * @return a pretty-printed XML-formatted string.
      */
-    protected static String getHumanReadableXml(final Node node) {
+    public static String getHumanReadableXml(final Node node) {
+        if (node == null) {
+            return "";
+        }
+
+        stripWhitespace(node);
+
         StringWriter toReturn = new StringWriter();
 
         try {
@@ -529,6 +535,30 @@ public final class XsdGeneratorHelper {
         }
 
         return toReturn.toString();
+    }
+
+    /**
+     * Recursively removes whitespace-only text nodes from the DOM tree.
+     * On JDK 9+, the XSLT transformer preserves existing whitespace text nodes while adding its
+     * own indentation when INDENT is enabled, which leads to accumulating blank lines between elements.
+     *
+     * @param node The DOM node to strip whitespace from.
+     */
+    private static void stripWhitespace(final Node node) {
+        if (node == null) {
+            return;
+        }
+
+        final NodeList children = node.getChildNodes();
+        for (int i = children.getLength() - 1; i >= 0; i--) {
+            final Node child = children.item(i);
+            if (child.getNodeType() == Node.TEXT_NODE
+                    && child.getNodeValue().trim().isEmpty()) {
+                node.removeChild(child);
+            } else if (child.getNodeType() == Node.ELEMENT_NODE) {
+                stripWhitespace(child);
+            }
+        }
     }
 
     //

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/XsdGeneratorHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/XsdGeneratorHelperTest.java
@@ -505,6 +505,57 @@ class XsdGeneratorHelperTest {
         assertEquals("xs", schema3NamespaceURI2PrefixMap.get("http://www.w3.org/2001/XMLSchema"));
     }
 
+    @Test
+    void validatePrettyPrintingDoesNotIntroduceEmptyLines() {
+        // Assemble
+        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" version=\"1.0\">\n"
+                + "  <xs:element name=\"foo\" type=\"xs:string\"/>\n"
+                + "  <xs:complexType name=\"bar\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element name=\"baz\" type=\"xs:string\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final Document document = XsdGeneratorHelper.parseXmlStream(new StringReader(xml));
+
+        // Act
+        final String prettyXml = XsdGeneratorHelper.getHumanReadableXml(document.getFirstChild());
+
+        // Assert: no empty/blank lines between elements
+        final String[] lines = prettyXml.split("\\R");
+        for (int i = 0; i < lines.length; i++) {
+            assertTrue(
+                    !lines[i].trim().isEmpty(),
+                    "Line " + i + " should not be blank, but was: [" + lines[i] + "] in XML:\n" + prettyXml);
+        }
+    }
+
+    @Test
+    void validateRepeatedPrettyPrintingDoesNotAccumulateEmptyLines() {
+        // Assemble
+        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" version=\"1.0\">\n"
+                + "  <xs:element name=\"foo\" type=\"xs:string\"/>\n"
+                + "  <xs:complexType name=\"bar\">\n"
+                + "    <xs:sequence>\n"
+                + "      <xs:element name=\"baz\" type=\"xs:string\"/>\n"
+                + "    </xs:sequence>\n"
+                + "  </xs:complexType>\n"
+                + "</xs:schema>\n";
+
+        final Document firstDoc = XsdGeneratorHelper.parseXmlStream(new StringReader(xml));
+        final String firstPassXml = XsdGeneratorHelper.getHumanReadableXml(firstDoc.getFirstChild());
+
+        // Act: second pass (parse the pretty-printed XML and pretty-print again)
+        final Document secondDoc = XsdGeneratorHelper.parseXmlStream(new StringReader(firstPassXml));
+        final String secondPassXml = XsdGeneratorHelper.getHumanReadableXml(secondDoc.getFirstChild());
+
+        // Assert
+        assertEquals(firstPassXml, secondPassXml, "Pretty-printing should be idempotent and not add blank lines.");
+    }
+
     //
     // Private helpers
     //


### PR DESCRIPTION
Fixes #160

### Summary of the Problem
On JDK 9 and higher (including JDK 11, 17, 21+), running `schemagen` with post-processing enabled (such as `transformSchemas`, `qualifyUnprefixedReferences`, or `createJavaDocAnnotations`, which is enabled by default) results in superfluous blank lines throughout generated XSD files. When multiple post-processing steps occur, the empty lines between elements accumulate further.

### Root Cause
Under JDK 9+ (following JDK-8176527 and internal Xalan serializer adjustments in `com.sun.org.apache.xml.internal.serializer.ToStream`), the XSLT `Transformer` configured with `OutputKeys.INDENT = "yes"` preserves existing whitespace `Text` nodes while simultaneously inserting its own indentation newlines before every element tag. Because DOM documents parsed from `schemagen`'s initial XSD output already contain newlines and indentation whitespace text nodes, serializing with indentation outputs both the existing text node and the transformer's newline, generating empty lines before every tag.

### Solution
1. Added `stripWhitespace(Node node)` in `XsdGeneratorHelper` to recursively remove whitespace-only `Text` nodes from the DOM tree before serializing with the XSLT transformer. Non-whitespace text nodes (such as content inside `<xs:documentation>`), XML comments, and CDATA sections are strictly preserved.
2. Invoked `stripWhitespace(node)` inside `XsdGeneratorHelper.getHumanReadableXml(Node node)`.
3. Added unit tests in `XsdGeneratorHelperTest` verifying that:
   - Pretty-printing does not produce blank/whitespace-only lines between schema elements.
   - Repeated pretty-printing passes are idempotent and do not accumulate empty lines.