### PR TITLE
Fix #145: Resolve constant expressions in JAXB annotations for JavaDoc extraction

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractor.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractor.java
@@ -38,6 +38,9 @@ import com.thoughtworks.qdox.model.JavaField;
 import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.JavaPackage;
 import com.thoughtworks.qdox.model.JavaSource;
+import com.thoughtworks.qdox.model.expression.AnnotationValue;
+import com.thoughtworks.qdox.model.expression.BinaryOperator;
+import com.thoughtworks.qdox.model.expression.FieldRef;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
@@ -179,8 +182,8 @@ public class JavaDocExtractor {
 
                 // Add the class-level JavaDoc
                 final String simpleClassName = currentClass.getName();
-                final String classXmlName =
-                        getAnnotationAttributeValueFrom(XmlType.class, "name", currentClass.getAnnotations());
+                final String classXmlName = getAnnotationAttributeValueFrom(
+                        XmlType.class, "name", currentClass.getAnnotations(), currentClass);
 
                 final ClassLocation classLocation = new ClassLocation(packageName, simpleClassName, classXmlName);
                 addEntry(dataHolder, classLocation, currentClass);
@@ -220,7 +223,7 @@ public class JavaDocExtractor {
                         // ==> annotatedXmlName == "integerSet"
                         //
                         annotatedXmlName = getAnnotationAttributeValueFrom(
-                                XmlElementWrapper.class, "name", currentFieldAnnotations);
+                                XmlElementWrapper.class, "name", currentFieldAnnotations, currentClass);
 
                         if (annotatedXmlName == null || annotatedXmlName.equals(DEFAULT_VALUE)) {
                             annotatedXmlName = currentField.getName();
@@ -229,17 +232,17 @@ public class JavaDocExtractor {
 
                     // Find the XML name if provided within an annotation.
                     if (annotatedXmlName == null) {
-                        annotatedXmlName =
-                                getAnnotationAttributeValueFrom(XmlElement.class, "name", currentFieldAnnotations);
+                        annotatedXmlName = getAnnotationAttributeValueFrom(
+                                XmlElement.class, "name", currentFieldAnnotations, currentClass);
                     }
 
                     if (annotatedXmlName == null) {
-                        annotatedXmlName =
-                                getAnnotationAttributeValueFrom(XmlAttribute.class, "name", currentFieldAnnotations);
+                        annotatedXmlName = getAnnotationAttributeValueFrom(
+                                XmlAttribute.class, "name", currentFieldAnnotations, currentClass);
                     }
                     if (annotatedXmlName == null) {
-                        annotatedXmlName =
-                                getAnnotationAttributeValueFrom(XmlEnumValue.class, "value", currentFieldAnnotations);
+                        annotatedXmlName = getAnnotationAttributeValueFrom(
+                                XmlEnumValue.class, "value", currentFieldAnnotations, currentClass);
                     }
 
                     // Add the field-level JavaDoc
@@ -284,7 +287,7 @@ public class JavaDocExtractor {
                         // ==> annotatedXmlName == "getIntegerSet"
                         //
                         annotatedXmlName = getAnnotationAttributeValueFrom(
-                                XmlElementWrapper.class, "name", currentMethodAnnotations);
+                                XmlElementWrapper.class, "name", currentMethodAnnotations, currentClass);
 
                         if (annotatedXmlName == null || annotatedXmlName.equals(DEFAULT_VALUE)) {
                             annotatedXmlName = currentMethod.getName();
@@ -294,12 +297,12 @@ public class JavaDocExtractor {
                     // Find the XML name if provided within an annotation.
                     if (annotatedXmlName == null) {
                         annotatedXmlName = getAnnotationAttributeValueFrom(
-                                XmlElement.class, "name", currentMethod.getAnnotations());
+                                XmlElement.class, "name", currentMethod.getAnnotations(), currentClass);
                     }
 
                     if (annotatedXmlName == null) {
                         annotatedXmlName = getAnnotationAttributeValueFrom(
-                                XmlAttribute.class, "name", currentMethod.getAnnotations());
+                                XmlAttribute.class, "name", currentMethod.getAnnotations(), currentClass);
                     }
 
                     // Add the method-level JavaDoc
@@ -335,8 +338,11 @@ public class JavaDocExtractor {
      * List, or {@code null} if none was found.
      * @since 2.2
      */
-    private static String getAnnotationAttributeValueFrom(
-            final Class<?> annotationType, final String attributeName, final List<JavaAnnotation> annotations) {
+    private String getAnnotationAttributeValueFrom(
+            final Class<?> annotationType,
+            final String attributeName,
+            final List<JavaAnnotation> annotations,
+            final JavaClass currentClass) {
 
         // QDox uses the fully qualified class name of the annotation for comparison.
         // Extract it.
@@ -356,15 +362,21 @@ public class JavaDocExtractor {
 
             if (annotation != null) {
 
-                final Object nameValue = annotation.getNamedParameter(attributeName);
+                final AnnotationValue propertyValue = annotation.getProperty(attributeName);
+                if (propertyValue != null) {
+                    toReturn = resolveAnnotationValue(propertyValue, currentClass, this.builder, 0);
+                }
 
-                if (nameValue != null && nameValue instanceof String) {
+                if (toReturn == null) {
+                    final Object nameValue = annotation.getNamedParameter(attributeName);
 
-                    toReturn = ((String) nameValue).trim();
+                    if (nameValue instanceof String) {
+                        toReturn = ((String) nameValue).trim();
 
-                    // Remove initial and trailing " chars, if present.
-                    if (toReturn.startsWith("\"") && toReturn.endsWith("\"")) {
-                        toReturn = (((String) nameValue).trim()).substring(1, toReturn.length() - 1);
+                        // Remove initial and trailing " chars, if present.
+                        if (toReturn.startsWith("\"") && toReturn.endsWith("\"") && toReturn.length() >= 2) {
+                            toReturn = toReturn.substring(1, toReturn.length() - 1);
+                        }
                     }
                 }
             }
@@ -372,6 +384,162 @@ public class JavaDocExtractor {
 
         // All Done.
         return toReturn;
+    }
+
+    private static String resolveAnnotationValue(
+            final AnnotationValue val,
+            final JavaClass currentClass,
+            final JavaProjectBuilder builder,
+            final int depth) {
+
+        if (val == null || depth > 5) {
+            return null;
+        }
+
+        if (val instanceof FieldRef) {
+            final FieldRef fr = (FieldRef) val;
+            final int partCount = fr.getPartCount();
+            if (partCount == 0) {
+                return null;
+            }
+
+            final String fieldName = fr.getNamePart(partCount - 1);
+            JavaClass targetClass = null;
+
+            if (partCount == 1) {
+                targetClass = currentClass;
+                if (targetClass != null
+                        && targetClass.getFieldByName(fieldName) == null
+                        && currentClass.getSource() != null
+                        && builder != null) {
+                    for (String imp : currentClass.getSource().getImports()) {
+                        if (imp.endsWith("." + fieldName)) {
+                            final String className = imp.substring(0, imp.length() - fieldName.length() - 1);
+                            final JavaClass c = builder.getClassByName(className);
+                            if (c != null && c.getFieldByName(fieldName) != null) {
+                                targetClass = c;
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else {
+                final StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < partCount - 1; i++) {
+                    if (sb.length() > 0) {
+                        sb.append(".");
+                    }
+                    sb.append(fr.getNamePart(i));
+                }
+                final String className = sb.toString();
+
+                if (currentClass != null
+                        && (className.equals(currentClass.getName())
+                                || className.equals(currentClass.getFullyQualifiedName()))) {
+                    targetClass = currentClass;
+                } else if (currentClass != null) {
+                    final JavaClass nested = currentClass.getNestedClassByName(className);
+                    if (nested != null && nested.getFieldByName(fieldName) != null) {
+                        targetClass = nested;
+                    }
+                    if (targetClass == null && currentClass.getSource() != null && builder != null) {
+                        for (String imp : currentClass.getSource().getImports()) {
+                            if (imp.equals(className) || imp.endsWith("." + className)) {
+                                final JavaClass c = builder.getClassByName(imp);
+                                if (c != null && c.getFieldByName(fieldName) != null) {
+                                    targetClass = c;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (targetClass == null && currentClass.getPackage() != null && builder != null) {
+                        final String fqcn = currentClass.getPackage().getName() + "." + className;
+                        final JavaClass c = builder.getClassByName(fqcn);
+                        if (c != null && c.getFieldByName(fieldName) != null) {
+                            targetClass = c;
+                        }
+                    }
+                    if (targetClass == null && builder != null) {
+                        final JavaClass c = builder.getClassByName(className);
+                        if (c != null && c.getFieldByName(fieldName) != null) {
+                            targetClass = c;
+                        }
+                    }
+                }
+            }
+
+            if (targetClass != null) {
+                final JavaField f = targetClass.getFieldByName(fieldName);
+                if (f != null) {
+                    final String init = f.getInitializationExpression();
+                    if (init != null) {
+                        final String parsed = parseStringExpression(init);
+                        if (parsed != null) {
+                            return parsed;
+                        }
+                        // Chained constant in the same class
+                        final JavaField chained = targetClass.getFieldByName(init.trim());
+                        if (chained != null) {
+                            final String chainedInit = chained.getInitializationExpression();
+                            if (chainedInit != null) {
+                                return parseStringExpression(chainedInit);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        } else if (val instanceof BinaryOperator) {
+            final BinaryOperator bin = (BinaryOperator) val;
+            final String left = resolveAnnotationValue(bin.getLeft(), currentClass, builder, depth + 1);
+            final String right = resolveAnnotationValue(bin.getRight(), currentClass, builder, depth + 1);
+            if (left != null && right != null) {
+                return left + right;
+            }
+            return null;
+        } else {
+            final Object paramVal = val.getParameterValue();
+            if (paramVal != null) {
+                final String s = paramVal.toString().trim();
+                if (s.startsWith("\"") && s.endsWith("\"") && s.length() >= 2) {
+                    return s.substring(1, s.length() - 1);
+                }
+                return s;
+            }
+            return null;
+        }
+    }
+
+    private static String parseStringExpression(String expr) {
+        if (expr == null) {
+            return null;
+        }
+        expr = expr.trim();
+        if (expr.startsWith("\"")
+                && expr.endsWith("\"")
+                && expr.length() >= 2
+                && expr.indexOf('"', 1) == expr.length() - 1) {
+            return expr.substring(1, expr.length() - 1);
+        }
+        if (expr.contains("+") && expr.contains("\"")) {
+            final String[] parts = expr.split("\\+");
+            final StringBuilder sb = new StringBuilder();
+            for (String part : parts) {
+                final String trimmed = part.trim();
+                if (trimmed.startsWith("\"") && trimmed.endsWith("\"") && trimmed.length() >= 2) {
+                    sb.append(trimmed.substring(1, trimmed.length() - 1));
+                } else {
+                    return null;
+                }
+            }
+            return sb.toString();
+        }
+        if (expr.startsWith("\"") && expr.endsWith("\"") && expr.length() >= 2) {
+            return expr.substring(1, expr.length() - 1);
+        }
+        return null;
     }
 
     private static boolean hasAnnotation(final Class<?> annotationType, final List<JavaAnnotation> annotations) {

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractorTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractorTest.java
@@ -2,6 +2,8 @@ package org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,6 +25,7 @@ import org.codehaus.mojo.jaxb2.shared.filters.pattern.PatternFileFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -394,6 +397,131 @@ class JavaDocExtractorTest {
         assertEquals(
                 "<code>true</code> if the provided Node should be processed by this NodeProcessor.",
                 methodTag2ValueMap.get("return"));
+    }
+
+    @Test
+    void validateXmlTypeConstantName(@TempDir File tempDir) throws Exception {
+        // Assemble
+        final String javaCode = "package com.example;\n"
+                + "import jakarta.xml.bind.annotation.XmlType;\n"
+                + "/**\n"
+                + " * Class documentation.\n"
+                + " */\n"
+                + "@XmlType(name = MyAnnotatedClass.CUSTOM_NAME)\n"
+                + "public class MyAnnotatedClass {\n"
+                + "    public static final String CUSTOM_NAME = \"MyCustomXmlType\";\n"
+                + "}\n";
+        File javaFile = new File(tempDir, "MyAnnotatedClass.java");
+        Files.write(javaFile.toPath(), javaCode.getBytes(StandardCharsets.UTF_8));
+
+        JavaDocExtractor extractor = new JavaDocExtractor(log);
+        extractor.setEncoding("UTF-8");
+        extractor.addSourceFiles(Collections.singletonList(javaFile));
+
+        // Act
+        SearchableDocumentation result = extractor.process();
+
+        // Assert
+        ClassLocation loc = result.getLocation("com.example.MyCustomXmlType");
+        assertNotNull(loc);
+        assertEquals("MyCustomXmlType", loc.getClassName());
+        assertEquals("MyCustomXmlType", loc.getAnnotationRenamedTo());
+    }
+
+    @Test
+    void validateXmlTypeConstantFromExternalClass(@TempDir File tempDir) throws Exception {
+        // Assemble
+        final String constCode = "package com.example;\n"
+                + "public class Constants {\n"
+                + "    public static final String EXTERNAL_NAME = \"ExternalXmlType\";\n"
+                + "}\n";
+        final String classCode = "package com.example;\n"
+                + "import jakarta.xml.bind.annotation.XmlType;\n"
+                + "/**\n"
+                + " * Class documentation.\n"
+                + " */\n"
+                + "@XmlType(name = Constants.EXTERNAL_NAME)\n"
+                + "public class MyClass {\n"
+                + "}\n";
+        File constFile = new File(tempDir, "Constants.java");
+        File classFile = new File(tempDir, "MyClass.java");
+        Files.write(constFile.toPath(), constCode.getBytes(StandardCharsets.UTF_8));
+        Files.write(classFile.toPath(), classCode.getBytes(StandardCharsets.UTF_8));
+
+        JavaDocExtractor extractor = new JavaDocExtractor(log);
+        extractor.setEncoding("UTF-8");
+        extractor.addSourceFiles(Arrays.asList(constFile, classFile));
+
+        // Act
+        SearchableDocumentation result = extractor.process();
+
+        // Assert
+        ClassLocation loc = result.getLocation("com.example.ExternalXmlType");
+        assertNotNull(loc);
+        assertEquals("ExternalXmlType", loc.getClassName());
+        assertEquals("ExternalXmlType", loc.getAnnotationRenamedTo());
+    }
+
+    @Test
+    void validateXmlElementAndAttributeConstantName(@TempDir File tempDir) throws Exception {
+        // Assemble
+        final String javaCode = "package com.example;\n"
+                + "import jakarta.xml.bind.annotation.XmlType;\n"
+                + "import jakarta.xml.bind.annotation.XmlElement;\n"
+                + "import jakarta.xml.bind.annotation.XmlAttribute;\n"
+                + "@XmlType\n"
+                + "public class MyElementClass {\n"
+                + "    public static final String ELEM_NAME = \"customElement\";\n"
+                + "    public static final String ATTR_NAME = \"customAttribute\";\n"
+                + "    @XmlElement(name = ELEM_NAME)\n"
+                + "    private String aField;\n"
+                + "    @XmlAttribute(name = ATTR_NAME)\n"
+                + "    private int anAttr;\n"
+                + "}\n";
+        File javaFile = new File(tempDir, "MyElementClass.java");
+        Files.write(javaFile.toPath(), javaCode.getBytes(StandardCharsets.UTF_8));
+
+        JavaDocExtractor extractor = new JavaDocExtractor(log);
+        extractor.setEncoding("UTF-8");
+        extractor.addSourceFiles(Collections.singletonList(javaFile));
+
+        // Act
+        SearchableDocumentation result = extractor.process();
+
+        // Assert
+        FieldLocation elemLoc = result.getLocation("com.example.MyElementClass#customElement");
+        assertNotNull(elemLoc, "Should find field by customElement name");
+        assertEquals("customElement", elemLoc.getAnnotationRenamedTo());
+
+        FieldLocation attrLoc = result.getLocation("com.example.MyElementClass#customAttribute");
+        assertNotNull(attrLoc, "Should find field by customAttribute name");
+        assertEquals("customAttribute", attrLoc.getAnnotationRenamedTo());
+    }
+
+    @Test
+    void validateConcatenatedConstantName(@TempDir File tempDir) throws Exception {
+        // Assemble
+        final String javaCode = "package com.example;\n"
+                + "import jakarta.xml.bind.annotation.XmlType;\n"
+                + "@XmlType(name = \"Prefix_\" + MyConcatClass.SUFFIX)\n"
+                + "public class MyConcatClass {\n"
+                + "    public static final String SUFFIX = \"CustomSuffix\";\n"
+                + "}\n";
+        File javaFile = new File(tempDir, "MyConcatClass.java");
+        Files.write(javaFile.toPath(), javaCode.getBytes(StandardCharsets.UTF_8));
+
+        JavaDocExtractor extractor = new JavaDocExtractor(log);
+        extractor.setEncoding("UTF-8");
+        extractor.addSourceFiles(Collections.singletonList(javaFile));
+
+        // Act
+        SearchableDocumentation result = extractor.process();
+
+        // Assert
+        ClassLocation loc = result.getLocation("com.example.Prefix_CustomSuffix");
+        assertNotNull(loc);
+        assertEquals("Prefix_CustomSuffix", loc.getClassName());
+        assertEquals("Prefix_CustomSuffix", loc.getAnnotationRenamedTo());
     }
 
     //


### PR DESCRIPTION
Fixes #145

### Summary of the Problem
When classes or fields are annotated with JAXB annotations using constants for XML names (e.g. `@XmlType(name = MyClass.MY_CONSTANT)`, `@XmlType(name = Constants.TYPE_NAME)`, or `@XmlElement(name = MY_FIELD_CONST)`), `schemagen` with `createJavaDocAnnotations=true` failed to attach JavaDoc comments to the corresponding elements/types in the generated XSD.

### Root Cause
`JavaDocExtractor` previously called `annotation.getNamedParameter(attributeName)` which, when supplied with a constant reference in source code, returned the raw identifier string (e.g. `"MyClass.MY_CONSTANT"` instead of the evaluated constant value `"MyClass"`). The extractor then stripped quotes only if the string began and ended with `"`, leaving `"MyClass.MY_CONSTANT"`. When `XsdAnnotationProcessor` subsequently matched XSD schema types against `ClassLocation`, the type names differed, and all class and member JavaDocs were dropped.

### Solution
1. In `JavaDocExtractor`, updated `getAnnotationAttributeValueFrom` to inspect `annotation.getProperty(attributeName)` (a QDox `AnnotationValue`).
2. Added `resolveAnnotationValue` which:
   - Resolves `FieldRef` instances (including same-class constants, static imports, nested classes, same-package classes, and imported external classes) to their constant initialization expressions.
   - Handles chained constant expressions and string literal concatenations (`BinaryOperator`).
   - Falls back gracefully to literal parameter values if constant resolution cannot find a field.
3. Added comprehensive unit tests in `JavaDocExtractorTest` validating:
   - `@XmlType` with same-class constant (`MyAnnotatedClass.CUSTOM_NAME`).
   - `@XmlType` with external class constant (`Constants.EXTERNAL_NAME`).
   - `@XmlElement` and `@XmlAttribute` with constants.
   - String concatenation with constants (`"Prefix_" + MyConcatClass.SUFFIX`).