### PR TITLE
Fix schemagen execution when path contains spaces (#137)

### DIFF
--- a/src/it/schemagen-handles-spaces in paths/invoker.properties
+++ b/src/it/schemagen-handles-spaces in paths/invoker.properties
@@ -1,1 +1,0 @@
-invoker.buildResult = failure

--- a/src/it/schemagen-handles-spaces in paths/verify.groovy
+++ b/src/it/schemagen-handles-spaces in paths/verify.groovy
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import groovy.xml.XmlSlurper
+
+def validateExistingFile(final File aFile, final int index) {
+  final String path = aFile.getCanonicalPath();
+  assert aFile.exists() && aFile.isFile(), "Missing required file [" + path + "]";
+  println "" + index + ". Expected file exists correctly. [" + path + "]";
+}
+
+def outputDir = new File(basedir, 'target/generated-resources/schemagen')
+def workDir = new File(basedir, 'target/schemagen-work/compile_scope')
+
+// Act: Validate content
+def xml = new XmlSlurper().parse(new File(workDir, 'schema1.xsd'));
+assert 1 == xml.complexType.size();
+assert 'someType' == xml.complexType[0].@name.text();
+
+// Assert
+println "\nValidating work directory content"
+println "==================================="
+validateExistingFile(new File(workDir, 'schema1.xsd'), 1);
+
+println "\nValidating output directory content"
+println "====================================="
+validateExistingFile(new File(outputDir, 'schema1.xsd'), 1);
+validateExistingFile(new File(outputDir, 'META-INF/JAXB/episode_schemagen.xjb'), 2);

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
@@ -393,8 +393,16 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
             // Compile the SchemaGen arguments
             final File episodeFile = getEpisodeFile(episodeFileName);
             final List<URL> sources = getSources();
+
+            File tempEpisodeFile = null;
+            File episodeFileToPass = episodeFile;
+            if (generateEpisode && episodeFile.getAbsolutePath().contains(" ")) {
+                tempEpisodeFile = createSafeTempEpisodeFile();
+                episodeFileToPass = tempEpisodeFile;
+            }
+
             final String[] schemaGenArguments =
-                    getSchemaGenArguments(environment.getClassPathAsArgument(), episodeFile, sources);
+                    getSchemaGenArguments(environment.getClassPathAsArgument(), episodeFileToPass, sources);
 
             // Ensure that the outputDirectory and workDirectory exists.
             // Clear them if configured to do so.
@@ -418,6 +426,12 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
                 // Fire the SchemaGenerator
                 final int result = SchemaGenerator.run(
                         schemaGenArguments, Thread.currentThread().getContextClassLoader());
+
+                if (tempEpisodeFile != null && tempEpisodeFile.exists()) {
+                    FileSystemUtilities.createDirectory(episodeFile.getParentFile(), false);
+                    FileUtils.copyFile(tempEpisodeFile, episodeFile);
+                    tempEpisodeFile.delete();
+                }
 
                 if (SCHEMAGEN_INCORRECT_OPTIONS == result) {
                     printSchemaGenCommandAndThrowException(
@@ -477,8 +491,8 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
                         final List<File> fileSources = new ArrayList<File>();
                         for (URL current : sources) {
                             if ("file".equalsIgnoreCase(current.getProtocol())) {
-                                final File toAdd = new File(current.getPath());
-                                if (toAdd.exists()) {
+                                final File toAdd = FileSystemUtilities.getFileFor(current, getEncoding(true));
+                                if (toAdd != null && toAdd.exists()) {
                                     fileSources.add(toAdd);
                                 } else {
                                     if (getLog().isWarnEnabled()) {
@@ -619,9 +633,9 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
         builder.withNamedArgument("d", getWorkDirectory().getAbsolutePath());
         builder.withNamedArgument("classpath", classPath);
 
-        // From 2.4: Always generate an episode file.
-        //
-        builder.withNamedArgument("episode", FileSystemUtilities.getCanonicalPath(episodeFile));
+        if (generateEpisode && episodeFile != null) {
+            builder.withNamedArgument("episode", FileSystemUtilities.getCanonicalPath(episodeFile));
+        }
 
         try {
 
@@ -931,6 +945,41 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
             throw new MojoExecutionException(msg, cause);
         } else {
             throw new MojoExecutionException(msg);
+        }
+    }
+
+    private File createSafeTempEpisodeFile() throws MojoExecutionException {
+        try {
+            final File tempFile = File.createTempFile("episode_", ".xjb");
+            if (!tempFile.getAbsolutePath().contains(" ")) {
+                tempFile.deleteOnExit();
+                return tempFile;
+            }
+            // If default temp directory contains spaces (e.g. username on Windows),
+            // attempt to use system temp directories without spaces
+            for (String fallbackPath : Arrays.asList(
+                    System.getenv("SystemDrive") != null
+                            ? System.getenv("SystemDrive") + File.separator + "Temp"
+                            : null,
+                    File.separator + "tmp",
+                    System.getProperty("user.home"))) {
+                if (fallbackPath != null) {
+                    final File fallbackDir = new File(fallbackPath);
+                    if (!fallbackDir.getAbsolutePath().contains(" ")
+                            && (fallbackDir.isDirectory() || fallbackDir.mkdirs())) {
+                        final File fallbackFile = File.createTempFile("episode_", ".xjb", fallbackDir);
+                        if (!fallbackFile.getAbsolutePath().contains(" ")) {
+                            fallbackFile.deleteOnExit();
+                            tempFile.delete();
+                            return fallbackFile;
+                        }
+                        fallbackFile.delete();
+                    }
+                }
+            }
+            return tempFile;
+        } catch (IOException e) {
+            throw new MojoExecutionException("Could not create temporary episode file", e);
         }
     }
 }

--- a/src/main/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilities.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilities.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.file.Path;
@@ -202,8 +203,12 @@ public final class FileSystemUtilities {
         File toReturn = null;
         if ("file".equalsIgnoreCase(protocol)) {
             try {
-                final String decodedPath = URLDecoder.decode(anURL.getPath(), encoding);
-                toReturn = new File(decodedPath);
+                try {
+                    toReturn = new File(anURL.toURI());
+                } catch (URISyntaxException | IllegalArgumentException e) {
+                    final String decodedPath = URLDecoder.decode(anURL.getPath(), encoding);
+                    toReturn = new File(decodedPath);
+                }
             } catch (Exception e) {
                 throw new IllegalArgumentException("Could not get the File for [" + anURL + "]", e);
             }

--- a/src/main/java/org/codehaus/mojo/jaxb2/shared/environment/classloading/ThreadContextClassLoaderBuilder.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/shared/environment/classloading/ThreadContextClassLoaderBuilder.java
@@ -330,7 +330,12 @@ public final class ThreadContextClassLoaderBuilder {
         URL toReturn = anURL;
         if ("file".equalsIgnoreCase(anURL.getProtocol())) {
 
-            final File theFile = new File(anURL.getPath());
+            File theFile;
+            try {
+                theFile = new File(anURL.toURI());
+            } catch (Exception e) {
+                theFile = new File(anURL.getPath());
+            }
             if (theFile.isDirectory()) {
                 try {
 

--- a/src/test/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilitiesTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilitiesTest.java
@@ -426,6 +426,41 @@ class FileSystemUtilitiesTest {
     }
 
     @Test
+    void validateGettingFileForUrlWithSpaces() {
+
+        // Assemble
+        final String resourcePath = "testdata/shared/urlhandling/file with spaces.txt";
+        final URL resource = getClass().getClassLoader().getResource(resourcePath);
+        assertNotNull(resource);
+
+        // Act
+        final File file = FileSystemUtilities.getFileFor(resource, "UTF-8");
+
+        // Assert
+        assertNotNull(file);
+        assertTrue(file.exists());
+        assertTrue(file.isFile());
+        assertEquals("file with spaces.txt", file.getName());
+    }
+
+    @Test
+    void validateGettingFileForUrlWithPlusCharacter() throws Exception {
+
+        // Assemble
+        final File tempFile = File.createTempFile("file+with+plus", ".txt");
+        tempFile.deleteOnExit();
+        final URL fileUrl = tempFile.toURI().toURL();
+
+        // Act
+        final File resolvedFile = FileSystemUtilities.getFileFor(fileUrl, "UTF-8");
+
+        // Assert
+        assertNotNull(resolvedFile);
+        assertTrue(resolvedFile.exists());
+        assertEquals(tempFile.getCanonicalPath(), resolvedFile.getCanonicalPath());
+    }
+
+    @Test
     void validateRelativizingPaths() throws Exception {
 
         // Assemble


### PR DESCRIPTION
Resolves #137

### Root Cause
When project paths or source paths contain spaces:
1. In `AbstractXsdGeneratorMojo`, resolving source files for JavaDoc post-processing used `final File toAdd = new File(current.getPath());` on source file URLs (`file:/.../path%20with%20spaces/...`). Because `URL.getPath()` retains `%20` percent-encoding, `toAdd.exists()` evaluated to `false` and logged warnings (`"Ignoring URL [...] as it is a nonexistent file"`), causing JavaDoc annotations to be dropped completely.
2. In JAXB RI / `txw2` (`StreamSerializer.java`), episode generation via `StreamResult(File)` converts the file to an ASCII URI string with percent-encoded spaces. `StreamSerializer`'s internal `convertURL()` method strips the `file:/` protocol prefix but never decodes `%20`, leading to `java.io.FileNotFoundException` on `new FileOutputStream(url)` when attempting to write the episode file into directories with spaces.
3. `FileSystemUtilities.getFileFor()` used `URLDecoder.decode(anURL.getPath(), encoding)`, which had the known defect of turning `+` characters in paths into spaces.
4. `AbstractXsdGeneratorMojo` unconditionally passed `-episode` to SchemaGen regardless of the configured `generateEpisode` parameter.

### Solution
- **Proper URL Decoding for JavaDoc Sources:** In `AbstractXsdGeneratorMojo`, use `FileSystemUtilities.getFileFor(current, getEncoding(true))` instead of `new File(current.getPath())`.
- **URI-First File Conversion:** In `FileSystemUtilities.getFileFor()` and `ThreadContextClassLoaderBuilder`, prefer `new File(anURL.toURI())` (with fallback to `URLDecoder`), which preserves characters like `+` and properly decodes URI percent-encodings.
- **Safe Temp Episode File:** When the target episode file path contains spaces, `AbstractXsdGeneratorMojo` generates the episode file into a safe temporary file without spaces to circumvent the `txw2` URI encoding bug, and copies it to the target episode path immediately upon completion.
- **Respect `generateEpisode`:** Only pass the `-episode` argument when `generateEpisode` is `true` and `episodeFile` is present.
- **Enable & Verify IT:** Removed `invoker.buildResult = failure` from `src/it/schemagen-handles-spaces in paths` and added `verify.groovy` to assert that the schema and episode files are generated properly.