### PR TITLE
Fix XJC failing to read linked schemas in non-ASCII paths (#274)

### DIFF
--- a/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/pom.xml
+++ b/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-linked-schemas-in-non-ascii-path</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Test XJC execution with linked schemas when project directory path contains non-ASCII characters.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/src/main/xsd/main.xsd
+++ b/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/src/main/xsd/main.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:test:nonascii"
+           xmlns:tns="urn:test:nonascii"
+           elementFormDefault="qualified">
+
+    <xs:include schemaLocation="sub.xsd"/>
+
+    <xs:complexType name="MainType">
+        <xs:sequence>
+            <xs:element name="child" type="tns:SubType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="root" type="tns:MainType"/>
+
+</xs:schema>

--- a/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/src/main/xsd/sub.xsd
+++ b/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/src/main/xsd/sub.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:test:nonascii"
+           xmlns:tns="urn:test:nonascii"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="SubType">
+        <xs:sequence>
+            <xs:element name="subValue" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+</xs:schema>

--- a/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/verify.groovy
+++ b/src/it/xjc-linked-schemas-in-non-ascii-path_æøå/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+
+String pathToGenerated = "target/generated-sources/jaxb/test/nonascii/"
+File mainType = new File(basedir, pathToGenerated + "MainType.java")
+File subType = new File(basedir, pathToGenerated + "SubType.java")
+File objectFactory = new File(basedir, pathToGenerated + "ObjectFactory.java")
+
+assert mainType.exists() && mainType.isFile(), "Missing expected generated file: " + mainType.path
+assert subType.exists() && subType.isFile(), "Missing expected generated file: " + subType.path
+assert objectFactory.exists() && objectFactory.isFile(), "Missing expected generated file: " + objectFactory.path

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -674,7 +674,12 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
             //         current.getAbsolutePath(), getProject().getBasedir());
 
             // Each XJB must be given as a separate argument.
-            builder.withPreCompiledArguments(Arrays.asList("-b", current.getAbsolutePath()));
+            // If the path contains non-ASCII characters, pass it as a percent-encoded ASCII URI
+            // to avoid URI syntax errors in Xerces/XJC when resolving schemas.
+            final String path = current.getAbsolutePath();
+            final String arg =
+                    FileSystemUtilities.containsNonAscii(path) ? current.toURI().toASCIIString() : path;
+            builder.withPreCompiledArguments(Arrays.asList("-b", arg));
         }
 
         final List<URL> sourceXSDs = getSources();
@@ -692,7 +697,15 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
                 // Shorten the argument if possible.
                 if ("file".equalsIgnoreCase(current.getProtocol())) {
                     try {
-                        unwrappedSourceXSDs.add(new File(current.toURI()).getPath());
+                        final String path = new File(current.toURI()).getPath();
+                        // If the path contains non-ASCII characters, pass it as a percent-encoded ASCII URI.
+                        // Passing a raw filesystem path with non-ASCII characters causes Xerces' internal URI
+                        // parser to reject the base URI and fail to resolve relative includes/imports.
+                        if (FileSystemUtilities.containsNonAscii(path)) {
+                            unwrappedSourceXSDs.add(current.toURI().toASCIIString());
+                        } else {
+                            unwrappedSourceXSDs.add(path);
+                        }
                     } catch (final URISyntaxException e) {
                         throw new MojoExecutionException(e.getMessage(), e);
                     }

--- a/src/main/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilities.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilities.java
@@ -558,6 +558,24 @@ public final class FileSystemUtilities {
     }
 
     /**
+     * Checks if the supplied string contains any non-ASCII characters (i.e. character code &gt; 127).
+     *
+     * @param text The string to check.
+     * @return {@code true} if the string contains non-ASCII characters, {@code false} otherwise.
+     */
+    public static boolean containsNonAscii(final String text) {
+        if (text == null) {
+            return false;
+        }
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) > 127) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * If the supplied fileOrDir is a File, it is added to the returned List if any of the filters Match.
      * If the supplied fileOrDir is a Directory, it is listed and any of the files immediately within the fileOrDir
      * directory are returned within the resulting List provided that they match any of the supplied filters.

--- a/src/test/java/org/codehaus/mojo/jaxb2/javageneration/XjcNonAsciiPathTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/javageneration/XjcNonAsciiPathTest.java
@@ -1,0 +1,108 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.sun.tools.xjc.Driver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test verifying that XJC resolves linked schemas and bindings when located in paths
+ * containing non-ASCII characters (such as æøå) and spaces.
+ */
+class XjcNonAsciiPathTest {
+
+    @Test
+    void testLinkedSchemaAndBindingInNonAsciiPath(@TempDir Path tempDir) throws Exception {
+        // Given
+        final Path nonAsciiDir = tempDir.resolve("proj with spaces and æøå test");
+        Files.createDirectories(nonAsciiDir);
+
+        final Path outDir = nonAsciiDir.resolve("target");
+        Files.createDirectories(outDir);
+
+        final Path episodeFile = outDir.resolve("sun-jaxb.episode");
+
+        final Path subXsd = nonAsciiDir.resolve("sub.xsd");
+        Files.writeString(
+                subXsd,
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"urn:test\" xmlns:tns=\"urn:test\" elementFormDefault=\"qualified\">\n"
+                        + "  <xs:complexType name=\"SubType\">\n"
+                        + "    <xs:sequence>\n"
+                        + "      <xs:element name=\"subField\" type=\"xs:string\"/>\n"
+                        + "    </xs:sequence>\n"
+                        + "  </xs:complexType>\n"
+                        + "</xs:schema>");
+
+        final Path mainXsd = nonAsciiDir.resolve("main.xsd");
+        Files.writeString(
+                mainXsd,
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"urn:test\" xmlns:tns=\"urn:test\" elementFormDefault=\"qualified\">\n"
+                        + "  <xs:include schemaLocation=\"sub.xsd\"/>\n"
+                        + "  <xs:element name=\"mainElem\" type=\"tns:SubType\"/>\n"
+                        + "</xs:schema>");
+
+        final Path bindingXjb = nonAsciiDir.resolve("binding.xjb");
+        Files.writeString(
+                bindingXjb,
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<jaxb:bindings xmlns:jaxb=\"https://jakarta.ee/xml/ns/jaxb\" jaxb:version=\"3.0\"\n"
+                        + "               xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n"
+                        + "               schemaLocation=\"main.xsd\" node=\"/xs:schema\">\n"
+                        + "    <jaxb:schemaBindings>\n"
+                        + "        <jaxb:package name=\"com.example.nonascii\"/>\n"
+                        + "    </jaxb:schemaBindings>\n"
+                        + "</jaxb:bindings>");
+
+        // 1. Verifying the bug: passing native File path causes Xerces to fail schema resolution
+        final ByteArrayOutputStream outStreamFail = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errStreamFail = new ByteArrayOutputStream();
+        final String[] argsFail = new String[] {
+            "-d",
+            outDir.toString(),
+            "-b",
+            bindingXjb.toFile().getPath(),
+            mainXsd.toFile().getPath()
+        };
+        final int resultFail = Driver.run(argsFail, new PrintStream(outStreamFail), new PrintStream(errStreamFail));
+        assertEquals(-1, resultFail, "Native File path should fail Xerces schema resolution due to non-ASCII chars");
+        assertTrue(
+                errStreamFail.toString().contains("Failed to read schema document 'sub.xsd'"),
+                "Expected Xerces error about failing to read schema document 'sub.xsd'");
+
+        // 2. Verifying the fix: passing percent-encoded ASCII URIs resolves cleanly
+        final ByteArrayOutputStream outStreamPass = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errStreamPass = new ByteArrayOutputStream();
+        final String[] argsPass = new String[] {
+            "-extension",
+            "-d",
+            outDir.toString(),
+            "-episode",
+            episodeFile.toString(),
+            "-b",
+            bindingXjb.toFile().toURI().toASCIIString(),
+            mainXsd.toFile().toURI().toASCIIString()
+        };
+        final int resultPass = Driver.run(argsPass, new PrintStream(outStreamPass), new PrintStream(errStreamPass));
+        assertEquals(0, resultPass, "Percent-encoded ASCII URI should succeed in XJC: " + errStreamPass);
+        assertFalse(
+                errStreamPass.toString().contains("Failed to read schema document 'sub.xsd'"),
+                "Should not contain schema resolution error");
+        assertTrue(
+                Files.exists(outDir.resolve("com/example/nonascii/SubType.java")),
+                "Expected SubType.java to be generated");
+        assertTrue(
+                Files.exists(outDir.resolve("com/example/nonascii/ObjectFactory.java")),
+                "Expected ObjectFactory.java to be generated");
+        assertTrue(Files.exists(episodeFile), "Expected episode file to be generated");
+    }
+}

--- a/src/test/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilitiesTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/shared/FileSystemUtilitiesTest.java
@@ -450,6 +450,22 @@ class FileSystemUtilitiesTest {
         }
     }
 
+    @Test
+    void validateContainsNonAscii() {
+        assertFalse(FileSystemUtilities.containsNonAscii(null));
+        assertFalse(FileSystemUtilities.containsNonAscii(""));
+        assertFalse(FileSystemUtilities.containsNonAscii("ascii-only-string"));
+        assertFalse(FileSystemUtilities.containsNonAscii("/Users/test/projects/src/main/xsd/schema.xsd"));
+        assertFalse(FileSystemUtilities.containsNonAscii(
+                "path with spaces and special chars: !#$%&'()*+,-./:;<=>?@[]^_`{|}~"));
+
+        assertTrue(FileSystemUtilities.containsNonAscii("æøå"));
+        assertTrue(FileSystemUtilities.containsNonAscii(
+                "/Users/blabla/æøå/src/main/resources/mets/submissionDescription.xsd"));
+        assertTrue(FileSystemUtilities.containsNonAscii("C:\\Users\\café\\schema.xsd"));
+        assertTrue(FileSystemUtilities.containsNonAscii("日本語/schema.xsd"));
+    }
+
     //
     // Private helpers
     //


### PR DESCRIPTION
### Summary of Changes

Resolves #274.

When a project or schema files reside within a directory path that contains non-ASCII characters (e.g., `æ`, `ø`, `å`, `ü`, `é`, etc.):
1. Passing a native local file path to XJC causes XJC's internal `fileToInputSource` to generate an unencoded URL system ID (`file:/Users/.../æøå/...`).
2. When Xerces attempts to resolve relative schema documents (e.g. `<xs:include schemaLocation="sub.xsd"/>` or `<xs:import schemaLocation="xlink.xsd"/>`), its internal URI parser (`com.sun.org.apache.xerces.internal.util.URI`) rejects unencoded non-ASCII characters with `MalformedURIException: Path contains invalid character: <char>`.
3. Because Xerces cannot parse the base URI, relative schema resolution against the base URI fails, resulting in:
   ```
   [WARNING] ... org.xml.sax.SAXParseException: schema_reference.4: Failed to read schema document 'sub.xsd', because 1) could not find the document; 2) the document could not be read; 3) the root element of the document is not <xsd:schema>.
   ```
   and subsequent compilation errors for unresolved types.

### Solution
- Added `FileSystemUtilities.containsNonAscii(String)` to check if a path contains any non-ASCII characters.
- In `AbstractJavaGeneratorMojo`, when the XSD or XJB path contains non-ASCII characters, supply the argument as a percent-encoded ASCII URI (`current.toURI().toASCIIString()`). For standard ASCII paths, local file paths are preserved as before.
- Xerces and XJC parse percent-encoded ASCII URIs without error and resolve relative schema documents successfully.
- Added comprehensive unit tests in `XjcNonAsciiPathTest` and `FileSystemUtilitiesTest`.
- Added an invoker integration test (`xjc-linked-schemas-in-non-ascii-path_æøå`) verifying end-to-end XJC schema compilation and class generation inside a directory with non-ASCII characters.