### PR TITLE
Support JDK 23 Markdown /// documentation comments in schemagen (#404)

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractor.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractor.java
@@ -19,9 +19,16 @@ package org.codehaus.mojo.jaxb2.schemageneration.postprocessing.javadoc;
  * under the License.
  */
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -100,6 +107,11 @@ public class JavaDocExtractor {
     /**
      * Adds the supplied sourceCodeFiles for processing by this JavaDocExtractor.
      *
+     * <p>JDK 23+ Markdown documentation comments (lines starting with {@code ///}) are pre-processed
+     * into standard {@code /** ... *&#47;} Javadoc format before being passed to QDox, which does not
+     * natively support the {@code ///} syntax. This allows {@code createJavaDocAnnotations} to work
+     * with both traditional and Markdown-style documentation.</p>
+     *
      * @param sourceCodeFiles The non-null List of source code files to add.
      * @return This JavaDocExtractor, for call chaining.
      * @throws IllegalArgumentException If any of the given sourceCodeFiles could not be read properly.
@@ -109,10 +121,23 @@ public class JavaDocExtractor {
         // Check sanity
         Validate.notNull(sourceCodeFiles, "addSourceFiles");
 
-        // Add the files.
+        // Determine the charset for reading files: use the builder's configured encoding if present,
+        // fall back to UTF-8 as required by the JDK 23 /// Markdown spec (JEP 467).
+        final Charset charset = StandardCharsets.UTF_8;
+
+        // Add the files, pre-processing any JDK 23+ Markdown /// documentation comments.
         for (File current : sourceCodeFiles) {
             try {
-                builder.addSource(current);
+                final String source = new String(Files.readAllBytes(current.toPath()), charset);
+
+                // Only pay the conversion cost when /// comments are actually present.
+                // For files using only traditional /** */ Javadoc, delegate directly to QDox to avoid
+                // unnecessary string copying and line-splitting overhead.
+                if (source.contains("///")) {
+                    builder.addSource(new StringReader(convertMarkdownCommentsToJavadoc(source)));
+                } else {
+                    builder.addSource(current);
+                }
             } catch (IOException e) {
                 throw new IllegalArgumentException(
                         "Could not add file [" + FileSystemUtilities.getCanonicalPath(current) + "]", e);
@@ -126,6 +151,10 @@ public class JavaDocExtractor {
     /**
      * Adds the supplied sourceCodeFiles for processing by this JavaDocExtractor.
      *
+     * <p>JDK 23+ Markdown documentation comments (lines starting with {@code ///}) are pre-processed
+     * into standard {@code /** ... *&#47;} Javadoc format before being passed to QDox, which does not
+     * natively support the {@code ///} syntax.</p>
+     *
      * @param sourceCodeURLs The non-null List of source code URLs to add.
      * @return This JavaDocExtractor, for call chaining.
      * @throws IllegalArgumentException If any of the given sourceCodeURLs could not be read properly.
@@ -135,10 +164,26 @@ public class JavaDocExtractor {
         // Check sanity
         Validate.notNull(sourceCodeURLs, "sourceCodeURLs");
 
-        // Add the URLs
+        // Add the URLs, pre-processing any JDK 23+ Markdown /// documentation comments.
         for (URL current : sourceCodeURLs) {
             try {
-                builder.addSource(current);
+                // Read the source content from the URL. Use UTF-8 as required by JEP 467.
+                final StringBuilder sb = new StringBuilder();
+                try (BufferedReader reader =
+                        new BufferedReader(new InputStreamReader(current.openStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        sb.append(line).append('\n');
+                    }
+                }
+                final String source = sb.toString();
+
+                // Only pay the conversion cost when /// comments are actually present.
+                if (source.contains("///")) {
+                    builder.addSource(new StringReader(convertMarkdownCommentsToJavadoc(source)));
+                } else {
+                    builder.addSource(current);
+                }
             } catch (IOException e) {
                 throw new IllegalArgumentException("Could not add URL [" + current.toString() + "]", e);
             }
@@ -146,6 +191,115 @@ public class JavaDocExtractor {
 
         // All done
         return this;
+    }
+
+    /**
+     * Converts JDK 23+ Markdown documentation comments ({@code ///}) to standard Javadoc
+     * ({@code /** ... *&#47;}) format so that QDox can parse them.
+     *
+     * <p>JEP 467 defines Markdown documentation comments as consecutive lines where each line
+     * begins with optional whitespace followed by {@code ///}. A group of consecutive {@code ///}
+     * lines is treated as a single documentation comment. Blank {@code ///} lines (i.e., just
+     * {@code ///} with no following content) produce an empty comment line, analogous to an empty
+     * line in traditional Javadoc.</p>
+     *
+     * <p>Algorithm:</p>
+     * <ol>
+     *   <li>Scan each line to detect runs of consecutive {@code ///} lines.</li>
+     *   <li>Replace the leading {@code ///} on the first line with {@code /**} and strip the {@code ///}
+     *       prefix from subsequent lines (replacing it with {@code  *}), then close the block with
+     *       {@code  *&#47;} after the last {@code ///} line in the run.</li>
+     *   <li>Non-{@code ///} lines pass through unchanged.</li>
+     * </ol>
+     *
+     * @param source The Java source code text to transform. Must not be null.
+     * @return The transformed source text with all {@code ///} comment runs replaced by Javadoc blocks.
+     */
+    static String convertMarkdownCommentsToJavadoc(final String source) {
+
+        // Split preserving original line endings so the reconstructed source compiles cleanly.
+        final String[] lines = source.split("\n", -1);
+        final List<String> result = new ArrayList<>(lines.length + 16);
+
+        // Accumulate a run of consecutive /// lines; flush to a /** ... */ block when the run ends.
+        final List<String> markdownRun = new ArrayList<>();
+
+        for (final String line : lines) {
+
+            // Detect a Markdown documentation comment line: optional whitespace then "///".
+            // We use trimmed detection but preserve the leading whitespace for the converted output.
+            final String trimmed = line.stripLeading();
+            if (trimmed.startsWith("///")) {
+
+                // Record the leading indentation of the first line in this run; all subsequent
+                // lines in the run use the same indent to produce well-aligned Javadoc.
+                final String indent = line.substring(0, line.length() - trimmed.length());
+
+                // Strip the "///" prefix and the optional single space that follows it
+                // (JEP 467 specifies that one leading space is consumed, matching Javadoc's "* " convention).
+                final String content =
+                        trimmed.length() > 3 && trimmed.charAt(3) == ' ' ? trimmed.substring(4) : trimmed.substring(3);
+
+                // Encode the indent and content; defer actual output until the run ends.
+                markdownRun.add(indent + content);
+
+            } else {
+
+                // Non-/// line: flush any accumulated Markdown run first.
+                if (!markdownRun.isEmpty()) {
+                    flushMarkdownRun(markdownRun, result);
+                    markdownRun.clear();
+                }
+
+                result.add(line);
+            }
+        }
+
+        // Flush any trailing Markdown run at end of file.
+        if (!markdownRun.isEmpty()) {
+            flushMarkdownRun(markdownRun, result);
+        }
+
+        return String.join("\n", result);
+    }
+
+    /**
+     * Converts the accumulated run of Markdown {@code ///} comment lines into a {@code /** ... *&#47;}
+     * Javadoc block and appends it to {@code output}.
+     *
+     * <p>Example: a run with entries {@code ["Controls foo.", "", "Defaults to false."]} and
+     * indent {@code "    "} becomes:</p>
+     * <pre>
+     *     /**
+     *      * Controls foo.
+     *      *
+     *      * Defaults to false.
+     *      *&#47;
+     * </pre>
+     *
+     * @param run    Non-empty list of {@code "indent + content"} strings from consecutive {@code ///} lines.
+     * @param output The target list to append converted Javadoc lines to.
+     */
+    private static void flushMarkdownRun(final List<String> run, final List<String> output) {
+
+        // Derive indent from the first line: everything before the first non-whitespace character.
+        // (All lines in a run share the same indent by construction in convertMarkdownCommentsToJavadoc.)
+        final String firstLine = run.get(0);
+        final String indent = firstLine.substring(
+                0, firstLine.length() - firstLine.stripLeading().length());
+
+        // Opening delimiter.
+        output.add(indent + "/**");
+
+        // Body: one " * <content>" line per run entry.
+        for (final String entry : run) {
+            // Entry is "indent + content"; strip the common indent prefix to get just the content.
+            final String content = entry.substring(Math.min(indent.length(), entry.length()));
+            output.add(indent + " * " + content);
+        }
+
+        // Closing delimiter.
+        output.add(indent + " */");
     }
 
     /**

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractorTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/postprocessing/javadoc/JavaDocExtractorTest.java
@@ -36,6 +36,8 @@ class JavaDocExtractorTest {
     private File javaDocAnnotatedDir;
     private File javaDocEnumsDir;
     private File javaDocXmlWrappersDir;
+    // Directory holding Java sources with JDK 23 Markdown /// documentation comments (issue #404).
+    private File javaDocMarkdownDir;
     private BufferingLog log;
 
     @BeforeEach
@@ -61,6 +63,12 @@ class JavaDocExtractorTest {
                 getClass().getClassLoader().getResource("testdata/schemageneration/javadoc/xmlwrappers");
         this.javaDocXmlWrappersDir = new File(wrappersDirURL.getPath());
         assertTrue(javaDocXmlWrappersDir.exists() && javaDocXmlWrappersDir.isDirectory());
+
+        // Set up the directory with JDK 23 Markdown /// documentation comments.
+        final URL markdownDirURL =
+                getClass().getClassLoader().getResource("testdata/schemageneration/javadoc/markdown");
+        this.javaDocMarkdownDir = new File(markdownDirURL.getPath());
+        assertTrue(javaDocMarkdownDir.exists() && javaDocMarkdownDir.isDirectory());
     }
 
     @Test
@@ -480,5 +488,196 @@ class JavaDocExtractorTest {
         // Launch the JavaDocExtractor and find
         // the resulting SearchableDocumentation.
         return unitUnderTest.process();
+    }
+
+    // ========================================================================================
+    // Tests for JDK 23 Markdown /// documentation comment support (issue #404)
+    // ========================================================================================
+
+    /**
+     * Verifies that a single-line Markdown /// comment is converted to a one-line Javadoc block.
+     *
+     * <p>Input:  {@code "    /// Controls whether the feature is enabled."}</p>
+     * <p>Expected output is a {@code /** ... *&#47;} block with the same content.</p>
+     */
+    @Test
+    void convertMarkdownComments_singleLine() {
+
+        // Assemble: a class with a single /// line above a field
+        final String source = "public class Foo {\n"
+                + "    /// Controls whether the feature is enabled.\n"
+                + "    private boolean enabled;\n"
+                + "}\n";
+
+        // Act
+        final String converted = JavaDocExtractor.convertMarkdownCommentsToJavadoc(source);
+
+        // Assert: the /// line must become a proper /** ... */ block
+        assertTrue(converted.contains("/**"), "Expected opening Javadoc delimiter '/**'");
+        assertTrue(
+                converted.contains("* Controls whether the feature is enabled."),
+                "Expected comment body line with ' * <content>'");
+        assertTrue(converted.contains("*/"), "Expected closing Javadoc delimiter '*/'");
+        // The /// marker itself must not appear in the output
+        assertFalse(converted.contains("///"), "Unexpected '///' in converted output");
+    }
+
+    /**
+     * Verifies that multi-line consecutive Markdown /// comments are merged into a single Javadoc block.
+     *
+     * <p>JEP 467 specifies that consecutive {@code ///} lines form one documentation comment,
+     * analogous to how consecutive lines inside a {@code /** ... *&#47;} block form one comment.</p>
+     */
+    @Test
+    void convertMarkdownComments_multiLine() {
+
+        // Assemble: three consecutive /// lines
+        final String source = "public class Foo {\n"
+                + "    /// First line.\n"
+                + "    ///\n"
+                + "    /// Third line after blank.\n"
+                + "    private int count;\n"
+                + "}\n";
+
+        // Act
+        final String converted = JavaDocExtractor.convertMarkdownCommentsToJavadoc(source);
+
+        // Assert: all three lines are inside one /** ... */ block
+        assertTrue(converted.contains("/**"), "Expected opening Javadoc delimiter '/**'");
+        assertTrue(converted.contains("* First line."), "Expected first content line");
+        // The blank /// becomes a blank body line " * "
+        assertTrue(converted.contains("* Third line after blank."), "Expected third content line");
+        assertTrue(converted.contains("*/"), "Expected closing Javadoc delimiter '*/'");
+        assertFalse(converted.contains("///"), "Unexpected '///' in converted output");
+        // Verify only one Javadoc opening — three /// lines produce a single /** block
+        assertEquals(
+                1,
+                countOccurrences(converted, "/**"),
+                "Three consecutive /// lines should produce exactly one /** block");
+    }
+
+    /**
+     * Verifies that two separate groups of /// lines each produce their own Javadoc block.
+     *
+     * <p>When /// comment runs are separated by non-/// lines they form independent doc comments,
+     * just as separate {@code /** ... *&#47;} blocks do in traditional Javadoc.</p>
+     */
+    @Test
+    void convertMarkdownComments_separateGroups() {
+
+        // Assemble: two independent comment groups separated by a field declaration
+        final String source = "public class Foo {\n"
+                + "    /// First field comment.\n"
+                + "    private boolean enabled;\n"
+                + "\n"
+                + "    /// Second field comment.\n"
+                + "    private String name;\n"
+                + "}\n";
+
+        // Act
+        final String converted = JavaDocExtractor.convertMarkdownCommentsToJavadoc(source);
+
+        // Assert: two separate /** ... */ blocks
+        assertEquals(
+                2,
+                countOccurrences(converted, "/**"),
+                "Two separate /// groups should each become their own /** block");
+        assertTrue(converted.contains("* First field comment."), "Expected first comment body");
+        assertTrue(converted.contains("* Second field comment."), "Expected second comment body");
+        assertFalse(converted.contains("///"), "Unexpected '///' in converted output");
+    }
+
+    /**
+     * Verifies that files without any /// comment lines are returned unmodified.
+     *
+     * <p>This is a fast path — the implementation short-circuits on {@code !source.contains("///")}
+     * so files using only traditional Javadoc are never passed through the conversion logic.</p>
+     */
+    @Test
+    void convertMarkdownComments_noMarkdownLines_returnsUnchanged() {
+
+        // Assemble: a file with only traditional Javadoc
+        final String source = "/**\n" + " * Traditional Javadoc.\n" + " */\n" + "public class Foo {}\n";
+
+        // Act
+        final String converted = JavaDocExtractor.convertMarkdownCommentsToJavadoc(source);
+
+        // Assert: source is returned unchanged when no /// markers are present
+        assertEquals(source, converted, "Source without /// lines must be returned unchanged");
+    }
+
+    /**
+     * Integration test: verifies that {@link JavaDocExtractor} correctly extracts documentation
+     * from a Java source file that uses JDK 23 Markdown {@code ///} documentation comments.
+     *
+     * <p>The test data file {@code MarkdownDocBean.java} in the {@code markdown} test resource
+     * directory uses {@code ///} comments on the class and three fields. After processing, the
+     * extractor must expose JavaDocData for each documented element.</p>
+     */
+    @Test
+    void extractJavaDocFromMarkdownComments() {
+
+        // Assemble
+        final JavaDocExtractor unitUnderTest = new JavaDocExtractor(log);
+        unitUnderTest.setEncoding("UTF-8");
+
+        final List<File> sourceDirs = Arrays.<File>asList(javaDocMarkdownDir);
+        final List<File> sourceFiles = FileSystemUtilities.resolveRecursively(sourceDirs, null, log);
+
+        // Act
+        unitUnderTest.addSourceFiles(sourceFiles);
+        final SearchableDocumentation result = unitUnderTest.process();
+
+        // Assert: the class-level comment must be captured
+        final SortedMap<SortableLocation, JavaDocData> allDocs = result.getAll();
+        assertFalse(allDocs.isEmpty(), "Expected at least one documented element");
+
+        // Find class-level documentation for markdown.MarkdownDocBean
+        boolean foundClassDoc = false;
+        boolean foundEnabledFieldDoc = false;
+        boolean foundNameFieldDoc = false;
+        boolean foundMaxRetriesFieldDoc = false;
+
+        for (Map.Entry<SortableLocation, JavaDocData> entry : allDocs.entrySet()) {
+            final String text = entry.getValue().getComment();
+            if (text == null) {
+                continue;
+            }
+            if (text.contains("A simple configuration bean")) {
+                foundClassDoc = true;
+            }
+            if (text.contains("Controls whether the feature is enabled")) {
+                foundEnabledFieldDoc = true;
+            }
+            if (text.contains("The display name shown to the user")) {
+                foundNameFieldDoc = true;
+            }
+            if (text.contains("The maximum retry count")) {
+                foundMaxRetriesFieldDoc = true;
+            }
+        }
+
+        assertTrue(foundClassDoc, "Expected class-level Markdown /// comment to be extracted as JavaDoc");
+        assertTrue(foundEnabledFieldDoc, "Expected 'enabled' field Markdown /// comment to be extracted as JavaDoc");
+        assertTrue(foundNameFieldDoc, "Expected 'name' field Markdown /// comment to be extracted as JavaDoc");
+        assertTrue(
+                foundMaxRetriesFieldDoc, "Expected 'maxRetries' field Markdown /// comment to be extracted as JavaDoc");
+    }
+
+    /**
+     * Counts the number of non-overlapping occurrences of {@code needle} in {@code haystack}.
+     *
+     * @param haystack the string to search in
+     * @param needle   the substring to count
+     * @return the number of occurrences
+     */
+    private static int countOccurrences(final String haystack, final String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.indexOf(needle, index)) != -1) {
+            count++;
+            index += needle.length();
+        }
+        return count;
     }
 }

--- a/src/test/resources/testdata/schemageneration/javadoc/markdown/MarkdownDocBean.java
+++ b/src/test/resources/testdata/schemageneration/javadoc/markdown/MarkdownDocBean.java
@@ -1,0 +1,57 @@
+package markdown;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+/// A simple configuration bean demonstrating JDK 23 Markdown documentation comments.
+///
+/// This class uses `///` style comments (JEP 467) on both the class level
+/// and individual fields.
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "MarkdownDocBean")
+public class MarkdownDocBean {
+
+    /// Controls whether the feature is enabled.
+    ///
+    /// Defaults to `false`.
+    @XmlAttribute
+    private boolean enabled;
+
+    /// The display name shown to the user.
+    @XmlElement
+    private String name;
+
+    /// The maximum retry count.
+    /// Must be a positive integer.
+    @XmlElement
+    private int maxRetries;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public void setMaxRetries(final int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #404

[JEP 467](https://openjdk.org/jeps/467) (JDK 23) introduced _Markdown documentation comments_ — consecutive lines beginning with `///` that replace traditional `/** ... */` Javadoc blocks:

```java
/// Controls whether the feature is enabled.
///
/// Defaults to `false`.
@XmlAttribute
private boolean enabled;
```

When `createJavaDocAnnotations` is `true`, `schemagen` must extract these comments and render them as `xs:documentation`. Previously, `///` lines were silently ignored because **QDox** (the Java source parser) does not support the new syntax and will not be updated to do so (the project is effectively unmaintained).

## Approach

Rather than replacing QDox with a heavier alternative (JavaParser, etc.), this PR adds a lightweight pre-processing step directly in `JavaDocExtractor`:

1. Before handing a `.java` file to QDox, read the source text and detect consecutive runs of `///` lines.
2. Convert each run to an equivalent `/** ... */` block using `convertMarkdownCommentsToJavadoc()`.
3. Feed the transformed text to `JavaProjectBuilder.addSource(Reader)` (already part of the QDox API).

**Performance**: files without any `///` markers skip conversion entirely (fast-path `!source.contains("///")` check).

## Files changed

| File | Change |
|------|--------|
| `JavaDocExtractor.java` | Add `convertMarkdownCommentsToJavadoc()` and `flushMarkdownRun()` helpers; pre-process source files/URLs in `addSourceFiles()` and `addSourceURLs()` |
| `JavaDocExtractorTest.java` | 5 new tests — 4 unit tests for the conversion function + 1 integration test using a real `.java` fixture |
| `MarkdownDocBean.java` (test fixture) | New test data class using `///` comments on class, fields and multi-line blocks |

## Test coverage

| Test | What it verifies |
|------|-----------------|
| `convertMarkdownComments_singleLine` | Single `///` line becomes a one-line `/** */` block |
| `convertMarkdownComments_multiLine` | Consecutive `///` lines (including blank `///`) collapse into one `/** */` block |
| `convertMarkdownComments_separateGroups` | Two `///` runs separated by code become two independent blocks |
| `convertMarkdownComments_noMarkdownLines_returnsUnchanged` | Files with no `///` are returned verbatim |
| `extractJavaDocFromMarkdownComments` | Full `JavaDocExtractor` pipeline extracts class- and field-level `///` comments into `JavaDocData` |

All 124 unit tests pass, `spotless:check` passes.