### PR TITLE
Resolve JAXB episodes from Maven dependency artifacts (#234)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>1.4.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>

--- a/src/it/xjc-episode-from-dependencies/invoker.properties
+++ b/src/it/xjc-episode-from-dependencies/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean install

--- a/src/it/xjc-episode-from-dependencies/pom.xml
+++ b/src/it/xjc-episode-from-dependencies/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-episode-from-dependencies</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <description>Purpose: Validate that JAXB episodes are resolved from Maven dependency
+        artifacts and used as external bindings (Issue #234).</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>schema-a</module>
+        <module>schema-b</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.11.0</version>
+                    <configuration>
+                        <source>11</source>
+                        <target>11</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/xjc-episode-from-dependencies/schema-a/pom.xml
+++ b/src/it/xjc-episode-from-dependencies/schema-a/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+        <artifactId>xjc-episode-from-dependencies</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xjc-episode-schema-a</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-a</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <packageName>com.example.a</packageName>
+                            <episodeFileName>schema-a-episode</episodeFileName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/xjc-episode-from-dependencies/schema-a/src/main/xsd/a.xsd
+++ b/src/it/xjc-episode-from-dependencies/schema-a/src/main/xsd/a.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:a="http://www.example.org/a"
+           targetNamespace="http://www.example.org/a"
+           elementFormDefault="qualified">
+
+    <xs:element name="A" type="a:AType"/>
+
+    <xs:complexType name="AType">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/src/it/xjc-episode-from-dependencies/schema-b/pom.xml
+++ b/src/it/xjc-episode-from-dependencies/schema-b/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+        <artifactId>xjc-episode-from-dependencies</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xjc-episode-schema-b</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+            <artifactId>xjc-episode-schema-a</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-b</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <packageName>com.example.b</packageName>
+                            <episodes>
+                                <episode>
+                                    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+                                    <artifactId>xjc-episode-schema-a</artifactId>
+                                    <version>1.0-SNAPSHOT</version>
+                                </episode>
+                            </episodes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/xjc-episode-from-dependencies/schema-b/src/main/xsd/b.xsd
+++ b/src/it/xjc-episode-from-dependencies/schema-b/src/main/xsd/b.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:b="http://www.example.org/b"
+           xmlns:a="http://www.example.org/a"
+           targetNamespace="http://www.example.org/b"
+           elementFormDefault="qualified">
+
+    <xs:import namespace="http://www.example.org/a" schemaLocation="../../../../schema-a/src/main/xsd/a.xsd"/>
+
+    <xs:element name="B" type="b:BType"/>
+
+    <xs:complexType name="BType">
+        <xs:sequence>
+            <xs:element name="wrapped" type="a:AType"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/src/it/xjc-episode-from-dependencies/verify.groovy
+++ b/src/it/xjc-episode-from-dependencies/verify.groovy
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.JarFile
+
+def log = new File(basedir, "build.log").text
+
+// 1. Module A generated its own classes and packaged the episode in its JAR.
+def aJar = new File(basedir, "schema-a/target/xjc-episode-schema-a-1.0-SNAPSHOT.jar")
+assert aJar.isFile() : "Module A JAR not found: " + aJar
+
+def jarFile = new JarFile(aJar)
+def jarEntries = []
+jarFile.entries().each { jarEntries << it.name }
+jarFile.close()
+assert jarEntries.contains("META-INF/JAXB/schema-a-episode.xjb")
+    : "Episode missing from module A JAR; entries: " + jarEntries
+
+// 2. Module B generated its own classes.
+def bObjectFactory = new File(basedir, "schema-b/target/generated-sources/jaxb/com/example/b/ObjectFactory.java")
+assert bObjectFactory.isFile() : "Module B ObjectFactory not generated."
+
+// 3. Module B did NOT regenerate module A's classes (episode applied).
+def aClassesInB = new File(basedir, "schema-b/target/generated-sources/jaxb/com/example/a")
+assert !aClassesInB.exists()
+    : "Module B re-generated module A classes; episode was not applied."
+
+// 4. B's generated code references A's reused types (AType from the dependency).
+def bType = new File(basedir, "schema-b/target/generated-sources/jaxb/com/example/b/BType.java")
+assert bType.isFile() : "Module B BType not generated."
+assert bType.text.contains("com.example.a") : "Module B generated sources do not reference module A types."
+
+// 5. The episode was extracted beneath the deterministic extraction directory in module B.
+def extracted = new File(
+    basedir,
+    "schema-b/target/jaxb2/episodes/"
+        + "org.codehaus.mojo.jaxb2.its/xjc-episode-schema-a/1.0-SNAPSHOT/"
+        + "META-INF/JAXB/schema-a-episode.xjb")
+assert extracted.isFile() : "Episode was not extracted to " + extracted
+
+// 6. The mojo logged the resolved episode.
+assert log.contains("Resolved JAXB episode org.codehaus.mojo.jaxb2.its:xjc-episode-schema-a:jar:1.0-SNAPSHOT")
+    : "Mojo did not log episode resolution."

--- a/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/AbstractJaxbMojo.java
@@ -415,7 +415,7 @@ public abstract class AbstractJaxbMojo extends AbstractMojo {
      * @return {@code true} to indicate that this AbstractJaxbMojo should be run since its generated files were
      * either stale or not present, and {@code false} otherwise.
      */
-    protected abstract boolean isReGenerationRequired();
+    protected abstract boolean isReGenerationRequired() throws MojoExecutionException;
 
     /**
      * <p>Implement this method to perform this Mojo's execution.

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -364,7 +364,7 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
      * {@inheritDoc}
      */
     @Override
-    protected boolean isReGenerationRequired() {
+    protected boolean isReGenerationRequired() throws MojoExecutionException {
 
         final File outputDir = getOutputDirectory();
         if (!FileSystemUtilities.containsFiles(outputDir)) {
@@ -635,7 +635,7 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
      *
      * @return A non-null List holding binding files.
      */
-    protected abstract List<File> getSourceXJBs();
+    protected abstract List<File> getSourceXJBs() throws MojoExecutionException;
 
     //
     // Private helpers

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/EpisodeArtifact.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/EpisodeArtifact.java
@@ -1,0 +1,193 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.mojo.jaxb2.shared.Validate;
+
+/**
+ * <p>Configuration model for a Maven artifact containing a JAXB episode file, to be
+ * used as an external binding by XJC when compiling another schema. Declared within
+ * the {@code episodes} parameter of the {@code xjc} goal:</p>
+ *
+ * <pre>
+ *     <code>
+ *         &lt;episodes&gt;
+ *             &lt;episode&gt;
+ *                 &lt;groupId&gt;com.acme.schemas&lt;/groupId&gt;
+ *                 &lt;artifactId&gt;schema-a&lt;/artifactId&gt;
+ *                 &lt;version&gt;1.4.0&lt;/version&gt;
+ *                 &lt;!-- optional elements: --&gt;
+ *                 &lt;type&gt;jar&lt;/type&gt;
+ *                 &lt;classifier&gt;&lt;/classifier&gt;
+ *                 &lt;resourcePath&gt;META-INF/sun-jaxb.episode&lt;/resourcePath&gt;
+ *                 &lt;optional&gt;false&lt;/optional&gt;
+ *             &lt;/episode&gt;
+ *         &lt;/episodes&gt;
+ *     </code>
+ * </pre>
+ *
+ * @see XjcMojo#episodes
+ * @since 4.1.1
+ */
+public class EpisodeArtifact {
+
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String type = "jar";
+    private String classifier;
+    private String resourcePath;
+    private boolean optional;
+
+    /**
+     * @return The Maven groupId of the episode artifact. Required.
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @param groupId The Maven groupId of the episode artifact. Required.
+     */
+    public void setGroupId(final String groupId) {
+        this.groupId = groupId;
+    }
+
+    /**
+     * @return The Maven artifactId of the episode artifact. Required.
+     */
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    /**
+     * @param artifactId The Maven artifactId of the episode artifact. Required.
+     */
+    public void setArtifactId(final String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    /**
+     * @return The Maven version of the episode artifact. Required.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @param version The Maven version of the episode artifact. Required.
+     */
+    public void setVersion(final String version) {
+        this.version = version;
+    }
+
+    /**
+     * @return The Maven artifact type (extension) of the episode artifact. Defaults to {@code jar}.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type The Maven artifact type (extension) of the episode artifact. Defaults to {@code jar}.
+     */
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return The optional Maven classifier of the episode artifact.
+     */
+    public String getClassifier() {
+        return classifier;
+    }
+
+    /**
+     * @param classifier The optional Maven classifier of the episode artifact.
+     */
+    public void setClassifier(final String classifier) {
+        this.classifier = classifier;
+    }
+
+    /**
+     * <p>An explicit path to the episode resource within the artifact, relative to its root
+     * (e.g. {@code META-INF/sun-jaxb.episode}). When omitted, the plugin discovers the episode
+     * using its standard search order and fails if the result is ambiguous.</p>
+     *
+     * @return The explicit episode resource path within the artifact, or {@code null} for auto-discovery.
+     */
+    public String getResourcePath() {
+        return resourcePath;
+    }
+
+    /**
+     * @param resourcePath An explicit path to the episode resource within the artifact, relative to its root.
+     */
+    public void setResourcePath(final String resourcePath) {
+        this.resourcePath = resourcePath;
+    }
+
+    /**
+     * @return {@code true} if a missing episode resource within this artifact should be logged and
+     * skipped rather than failing the build. Defaults to {@code false}.
+     */
+    public boolean isOptional() {
+        return optional;
+    }
+
+    /**
+     * @param optional {@code true} if a missing episode resource should be skipped rather than failing the build.
+     */
+    public void setOptional(final boolean optional) {
+        this.optional = optional;
+    }
+
+    /**
+     * Validates that the mandatory elements of this episode artifact are present.
+     *
+     * @throws IllegalArgumentException if groupId, artifactId or version is missing.
+     */
+    public void validate() {
+        Validate.notEmpty(groupId, "groupId");
+        Validate.notEmpty(artifactId, "artifactId");
+        Validate.notEmpty(version, "version");
+    }
+
+    /**
+     * @return The coordinate string {@code groupId:artifactId:type[:classifier]:version}.
+     */
+    public String getCoordinate() {
+        final StringBuilder sb = new StringBuilder()
+                .append(groupId)
+                .append(':')
+                .append(artifactId)
+                .append(':')
+                .append(type == null ? "jar" : type);
+        if (classifier != null && !classifier.isEmpty()) {
+            sb.append(':').append(classifier);
+        }
+        return sb.append(':').append(version).toString();
+    }
+
+    @Override
+    public String toString() {
+        return getCoordinate();
+    }
+}

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/EpisodeJarSupport.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/EpisodeJarSupport.java
@@ -1,0 +1,208 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Locates JAXB episode resources within artifact JARs and materializes them as local files
+ * suitable for XJC external binding inputs. The episode discovery order is:
+ *
+ * <ol>
+ *     <li>An explicitly configured resource path, if provided.</li>
+ *     <li>{@code META-INF/sun-jaxb.episode} (the JAXB RI convention).</li>
+ *     <li>{@code META-INF/JAXB/sun-jaxb.episode.xjb}.</li>
+ *     <li>The single {@code .xjb} file directly within {@code META-INF/JAXB/} (the location used
+ *     by this plugin when packaging generated episodes), provided exactly one such file exists.</li>
+ * </ol>
+ *
+ * @see EpisodeArtifact
+ * @since 4.1.1
+ */
+public final class EpisodeJarSupport {
+
+    /**
+     * The standard JAXB RI episode resource location.
+     */
+    public static final String STANDARD_EPISODE_RESOURCE = "META-INF/sun-jaxb.episode";
+
+    /**
+     * The episode location used by this plugin's own {@code getEpisodeFile} mechanism.
+     */
+    public static final String MOJOHAUS_EPISODE_DIRECTORY = "META-INF/JAXB/";
+
+    /**
+     * Hide constructor for utility classes.
+     */
+    private EpisodeJarSupport() {}
+
+    /**
+     * <p>Selects the episode entry within the supplied artifact file, following the discovery
+     * order defined by this class. Extracted episode files preserve the timestamp of the source
+     * JAR entry, so that incremental builds re-generate only when the episode artifact changes.</p>
+     *
+     * @param artifactFile         The resolved artifact file (JAR) to search.
+     * @param explicitResourcePath An explicit resource path within the artifact, or {@code null} for
+     *                             auto-discovery.
+     * @param coordinate           The Maven coordinate of the artifact, used in diagnostics.
+     * @return The name of the selected JAR entry, or {@code null} if no episode was found.
+     * @throws MojoExecutionException If the artifact is not a readable JAR, an explicitly configured
+     *                                resource path does not exist, or multiple episode candidates exist.
+     */
+    public static String selectEpisodeEntry(
+            final File artifactFile, final String explicitResourcePath, final String coordinate)
+            throws MojoExecutionException {
+
+        if (!artifactFile.isFile()) {
+            throw new MojoExecutionException("JAXB episode artifact " + coordinate + " resolved to ["
+                    + artifactFile.getAbsolutePath()
+                    + "] which is not a readable file. For reactor modules, ensure the module is packaged "
+                    + "(e.g. run 'mvn package' or 'mvn install') before this module's xjc goal executes.");
+        }
+
+        final List<String> entryNames = listEntryNames(artifactFile);
+
+        if (explicitResourcePath != null && !explicitResourcePath.isEmpty()) {
+            if (entryNames.contains(explicitResourcePath)) {
+                return explicitResourcePath;
+            }
+            throw new MojoExecutionException("Configured episode resource path [" + explicitResourcePath
+                    + "] does not exist within artifact " + coordinate + " [" + artifactFile.getAbsolutePath()
+                    + "].");
+        }
+
+        if (entryNames.contains(STANDARD_EPISODE_RESOURCE)) {
+            return STANDARD_EPISODE_RESOURCE;
+        }
+
+        if (entryNames.contains(MOJOHAUS_EPISODE_DIRECTORY + "sun-jaxb.episode.xjb")) {
+            return MOJOHAUS_EPISODE_DIRECTORY + "sun-jaxb.episode.xjb";
+        }
+
+        final List<String> candidates = new ArrayList<>();
+        for (String current : entryNames) {
+            if (current.startsWith(MOJOHAUS_EPISODE_DIRECTORY)
+                    && current.endsWith(".xjb")
+                    && current.indexOf('/', MOJOHAUS_EPISODE_DIRECTORY.length()) < 0) {
+                candidates.add(current);
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        if (candidates.size() > 1) {
+            Collections.sort(candidates);
+            throw new MojoExecutionException("Multiple JAXB episode resources found in artifact " + coordinate
+                    + ": " + candidates + ". Configure <resourcePath> within the <episode> element to select "
+                    + "one explicitly.");
+        }
+        return candidates.get(0);
+    }
+
+    /**
+     * <p>Extracts the supplied entry from the artifact JAR to a deterministic location beneath
+     * {@code extractionRoot}: {@code groupId/artifactId/version/entryName}. Guarded against
+     * path traversal (ZIP-slip). The extracted file is stamped with the JAR entry's timestamp
+     * (or the artifact file's, if the entry has none), enabling stable incremental builds.</p>
+     *
+     * @param artifactFile  The resolved artifact file (JAR).
+     * @param entryName     The JAR entry name to extract.
+     * @param extractionRoot The root directory beneath which the entry is materialized.
+     * @param groupId       The groupId of the artifact (used for the target path).
+     * @param artifactId    The artifactId of the artifact (used for the target path).
+     * @param version       The version of the artifact (used for the target path).
+     * @return The extracted, existing episode file.
+     * @throws MojoExecutionException If the JAR cannot be read or the entry cannot be extracted.
+     */
+    public static File extractEpisodeEntry(
+            final File artifactFile,
+            final String entryName,
+            final Path extractionRoot,
+            final String groupId,
+            final String artifactId,
+            final String version)
+            throws MojoExecutionException {
+
+        if (entryName == null || entryName.isEmpty() || entryName.startsWith("/")) {
+            throw new MojoExecutionException("Invalid episode entry path within artifact: " + entryName);
+        }
+        for (String segment : entryName.split("/")) {
+            if ("..".equals(segment)) {
+                throw new MojoExecutionException("Invalid episode entry path within artifact: " + entryName);
+            }
+        }
+
+        final Path targetPath = extractionRoot
+                .resolve(groupId)
+                .resolve(artifactId)
+                .resolve(version)
+                .resolve(entryName)
+                .normalize();
+
+        if (!targetPath.startsWith(extractionRoot.normalize() + File.separator)) {
+            throw new MojoExecutionException("Invalid episode entry path within artifact: " + entryName);
+        }
+
+        try (JarFile jarFile = new JarFile(artifactFile)) {
+            final JarEntry entry = jarFile.getJarEntry(entryName);
+            if (entry == null) {
+                throw new MojoExecutionException("Episode entry [" + entryName + "] not found within artifact ["
+                        + artifactFile.getAbsolutePath() + "].");
+            }
+            Files.createDirectories(targetPath.getParent());
+            try (InputStream is = jarFile.getInputStream(entry)) {
+                Files.copy(is, targetPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+            final long entryTime = entry.getTime() > 0 ? entry.getTime() : artifactFile.lastModified();
+            if (!targetPath.toFile().setLastModified(entryTime)) {
+                // Non-fatal: the extraction result exists, but incremental staleness may
+                // re-generate more often than strictly required.
+            }
+            return targetPath.toFile();
+        } catch (IOException e) {
+            throw new MojoExecutionException(
+                    "Could not extract episode entry [" + entryName + "] from artifact ["
+                            + artifactFile.getAbsolutePath() + "].",
+                    e);
+        }
+    }
+
+    private static List<String> listEntryNames(final File jarFile) throws MojoExecutionException {
+        try (JarFile theJar = new JarFile(jarFile)) {
+            final List<String> entryNames =
+                    theJar.stream().map(JarEntry::getName).collect(java.util.stream.Collectors.toList());
+            return entryNames;
+        } catch (IOException e) {
+            throw new MojoExecutionException("Could not read artifact JAR [" + jarFile.getAbsolutePath() + "].", e);
+        }
+    }
+}

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
@@ -19,14 +19,23 @@ package org.codehaus.mojo.jaxb2.javageneration;
  * under the License.
  */
 
+import javax.inject.Inject;
+
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -38,6 +47,13 @@ import org.codehaus.mojo.jaxb2.shared.FileSystemUtilities;
 import org.codehaus.mojo.jaxb2.shared.filters.Filter;
 import org.codehaus.mojo.jaxb2.shared.filters.Filters;
 import org.codehaus.mojo.jaxb2.shared.filters.pattern.PatternFileFilter;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
 
 /**
  * <p>Mojo that creates compile-scope Java source or binaries from XML schema(s)
@@ -175,6 +191,97 @@ public class XjcMojo extends AbstractJavaGeneratorMojo {
     private List<String> xjbSources;
 
     /**
+     * <p>Parameter holding a List of Maven artifacts whose JAXB episode files should be used as
+     * external bindings by XJC. This enables modular JAXB compilation: a schema module A can
+     * generate its Java model and episode file, and a downstream module B can compile its own
+     * schema against A's namespace while reusing A's generated types instead of generating
+     * duplicates.</p>
+     * <p>Each episode artifact is resolved using Maven Resolver; the episode resource is located
+     * within the artifact (see {@link EpisodeJarSupport} for the discovery order) and materialized
+     * beneath {@code episodeExtractionDirectory} before being handed to XJC as an external
+     * binding file.</p>
+     * <p><strong>Note:</strong> an episode only prevents duplicate Java class generation. The
+     * imported XSD itself must still be resolvable by XJC, through a regular {@code schemaLocation},
+     * an XML catalog, or an unpack step.</p>
+     * <p><strong>Example:</strong></p>
+     * <pre>
+     *     <code>
+     *         &lt;episodes&gt;
+     *             &lt;episode&gt;
+     *                 &lt;groupId&gt;com.acme.schemas&lt;/groupId&gt;
+     *                 &lt;artifactId&gt;schema-a&lt;/artifactId&gt;
+     *                 &lt;version&gt;1.4.0&lt;/version&gt;
+     *             &lt;/episode&gt;
+     *         &lt;/episodes&gt;
+     *     </code>
+     * </pre>
+     *
+     * @see EpisodeArtifact
+     * @see EpisodeJarSupport
+     * @since 4.1.1
+     */
+    @Parameter(required = false)
+    private List<EpisodeArtifact> episodes;
+
+    /**
+     * <p>When {@code true}, all eligible project dependencies (by default within the {@code compile}
+     * or {@code runtime} scopes, and non-transitive unless {@code includeTransitiveEpisodes} is set)
+     * are scanned for JAXB episode resources, which are then used as external bindings by XJC.
+     * Ordinary dependencies without episode resources are ignored. Defaults to {@code false} for
+     * safety: explicit {@code episodes} declarations make the code-generation boundary visible.</p>
+     *
+     * @see #episodes
+     * @see #includeTransitiveEpisodes
+     * @since 4.1.1
+     */
+    @Parameter(defaultValue = "false")
+    private boolean useDependenciesAsEpisodes;
+
+    /**
+     * <p>When {@code useDependenciesAsEpisodes} is {@code true}, this flag controls whether
+     * transitive dependencies are also scanned for JAXB episode resources, or only direct project
+     * dependencies. Defaults to {@code false}.</p>
+     *
+     * @see #useDependenciesAsEpisodes
+     * @since 4.1.1
+     */
+    @Parameter(defaultValue = "false")
+    private boolean includeTransitiveEpisodes;
+
+    /**
+     * <p>The directory beneath which episode resources from dependency artifacts are materialized,
+     * in a deterministic {@code groupId/artifactId/version} layout. Defaults to
+     * {@code ${project.build.directory}/jaxb2/episodes}.</p>
+     *
+     * @since 4.1.1
+     */
+    @Parameter(defaultValue = "${project.build.directory}/jaxb2/episodes")
+    private File episodeExtractionDirectory;
+
+    /**
+     * The Maven Resolver service, injected via JSR-330, used to resolve explicit episode artifacts.
+     */
+    @Inject
+    private RepositorySystem repositorySystem;
+
+    /**
+     * The session-scoped Maven Resolver session for the current build.
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repositorySystemSession;
+
+    /**
+     * The remote repositories declared by the project, used when resolving explicit episode artifacts.
+     */
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true)
+    private List<RemoteRepository> remoteProjectRepositories;
+
+    /**
+     * Memoized episode binding files, resolved at most once per mojo execution.
+     */
+    private List<File> episodeBindings;
+
+    /**
      * <p>Parameter holding a List of Filters, used to match all files under the {@code sources} directories
      * which should <strong>not</strong> be considered XJC source files. (The filters identify files to
      * exclude, and hence this parameter is called {@code xjcSourceExcludeFilters}). If a file under any of the
@@ -290,14 +397,213 @@ public class XjcMojo extends AbstractJavaGeneratorMojo {
      * {@inheritDoc}
      */
     @Override
-    protected List<File> getSourceXJBs() {
+    protected List<File> getSourceXJBs() throws MojoExecutionException {
 
         final List<Filter<File>> excludePatterns =
                 xjbExcludeFilters == null ? STANDARD_XJB_EXCLUDE_FILTERS : xjbExcludeFilters;
         Filters.initialize(getLog(), excludePatterns);
 
-        return FileSystemUtilities.filterFiles(
-                getProject().getBasedir(), xjbSources, STANDARD_XJB_DIRECTORY, getLog(), "xjbSources", excludePatterns);
+        final List<File> bindings = new ArrayList<>(FileSystemUtilities.filterFiles(
+                getProject().getBasedir(),
+                xjbSources,
+                STANDARD_XJB_DIRECTORY,
+                getLog(),
+                "xjbSources",
+                excludePatterns));
+
+        bindings.addAll(resolveEpisodeBindings());
+        return bindings;
+    }
+
+    /**
+     * Resolves all configured and/or discovered dependency episode bindings, in deterministic order:
+     * <ol>
+     *     <li>Explicit {@code episodes} declarations, in configuration order.</li>
+     *     <li>Automatically discovered dependency episodes, in artifact coordinate order.</li>
+     * </ol>
+     * The result is memoized for the remainder of this mojo execution.
+     *
+     * @return A non-null List of local, existing episode binding files.
+     */
+    private List<File> resolveEpisodeBindings() throws MojoExecutionException {
+
+        if (episodeBindings != null) {
+            return episodeBindings;
+        }
+
+        if ((episodes == null || episodes.isEmpty()) && !useDependenciesAsEpisodes) {
+            episodeBindings = Collections.emptyList();
+            return episodeBindings;
+        }
+
+        final List<File> result = new ArrayList<>();
+        final Set<String> handled = new LinkedHashSet<>();
+        final File extractionRoot = FileSystemUtilities.getCanonicalFile(episodeExtractionDirectory);
+
+        if (episodes != null) {
+            for (EpisodeArtifact current : episodes) {
+                current.validate();
+
+                final org.eclipse.aether.artifact.Artifact resolved = resolveEpisodeArtifact(current);
+                final String entry = EpisodeJarSupport.selectEpisodeEntry(
+                        resolved.getFile(), current.getResourcePath(), current.getCoordinate());
+
+                if (entry == null) {
+                    if (current.isOptional()) {
+                        getLog().warn("No JAXB episode resource found within optional episode artifact "
+                                + current.getCoordinate() + "; skipping.");
+                        continue;
+                    }
+                    throw new MojoExecutionException("No JAXB episode resource found within artifact "
+                            + current.getCoordinate() + " ["
+                            + resolved.getFile().getAbsolutePath()
+                            + "]. Configure <resourcePath> if the episode resides at a non-standard location.");
+                }
+
+                final File extracted = EpisodeJarSupport.extractEpisodeEntry(
+                        resolved.getFile(),
+                        entry,
+                        extractionRoot.toPath(),
+                        current.getGroupId(),
+                        current.getArtifactId(),
+                        current.getVersion());
+
+                getLog().info("Resolved JAXB episode " + current.getCoordinate() + " (" + entry + ") -> "
+                        + extracted.getAbsolutePath());
+
+                result.add(extracted);
+                handled.add(current.getCoordinate() + ":" + entry);
+            }
+        }
+
+        if (useDependenciesAsEpisodes) {
+            for (final Map.Entry<Artifact, String> candidate :
+                    findDependencyEpisodeCandidates().entrySet()) {
+                final Artifact artifact = candidate.getKey();
+                final String entry = candidate.getValue();
+                final String dedupeKey = coordinateOf(artifact) + ":" + entry;
+
+                if (handled.contains(dedupeKey)) {
+                    continue;
+                }
+
+                final File extracted = EpisodeJarSupport.extractEpisodeEntry(
+                        artifact.getFile(),
+                        entry,
+                        extractionRoot.toPath(),
+                        artifact.getGroupId(),
+                        artifact.getArtifactId(),
+                        artifact.getVersion());
+
+                getLog().debug("Discovered JAXB episode in dependency " + coordinateOf(artifact) + " (" + entry
+                        + ") -> " + extracted.getAbsolutePath());
+
+                result.add(extracted);
+                handled.add(dedupeKey);
+            }
+        }
+
+        episodeBindings = result;
+        return episodeBindings;
+    }
+
+    /**
+     * Scans the project's resolved dependency graph for episode resources. Ordinary dependencies
+     * without episode resources are skipped at debug level.
+     */
+    private Map<Artifact, String> findDependencyEpisodeCandidates() throws MojoExecutionException {
+
+        final Set<String> directDependencyKeys = new LinkedHashSet<>();
+        if (!includeTransitiveEpisodes) {
+            final List<Dependency> directDependencies = getProject().getDependencies();
+            if (directDependencies != null) {
+                for (Dependency current : directDependencies) {
+                    directDependencyKeys.add(
+                            current.getGroupId() + ":" + current.getArtifactId() + ":" + current.getVersion());
+                }
+            }
+        }
+
+        final List<Artifact> eligible = new ArrayList<>();
+        for (Artifact current : getProject().getArtifacts()) {
+            if (!"jar".equals(current.getType())
+                    || current.getFile() == null
+                    || !current.getFile().isFile()
+                    || !isEligibleScope(current)) {
+                continue;
+            }
+            if (!includeTransitiveEpisodes
+                    && !directDependencyKeys.contains(
+                            current.getGroupId() + ":" + current.getArtifactId() + ":" + current.getVersion())) {
+                getLog().debug("Ignoring transitive dependency " + coordinateOf(current)
+                        + " for episode scanning; set includeTransitiveEpisodes to include it.");
+                continue;
+            }
+            eligible.add(current);
+        }
+
+        eligible.sort(Comparator.comparing(Artifact::getGroupId)
+                .thenComparing(Artifact::getArtifactId)
+                .thenComparing(Artifact::getVersion)
+                .thenComparing(a -> a.getClassifier() == null ? "" : a.getClassifier()));
+
+        final Map<Artifact, String> candidates = new LinkedHashMap<>();
+        for (Artifact current : eligible) {
+            final String entry = EpisodeJarSupport.selectEpisodeEntry(current.getFile(), null, coordinateOf(current));
+            if (entry != null) {
+                candidates.put(current, entry);
+            } else {
+                getLog().debug("No JAXB episode resource within dependency " + coordinateOf(current) + "; skipping.");
+            }
+        }
+        return candidates;
+    }
+
+    private boolean isEligibleScope(final Artifact artifact) {
+        final String scope = artifact.getScope();
+        return Artifact.SCOPE_COMPILE.equals(scope) || Artifact.SCOPE_RUNTIME.equals(scope);
+    }
+
+    private String coordinateOf(final Artifact artifact) {
+        final StringBuilder sb = new StringBuilder()
+                .append(artifact.getGroupId())
+                .append(':')
+                .append(artifact.getArtifactId())
+                .append(':')
+                .append(artifact.getType());
+        if (artifact.getClassifier() != null && !artifact.getClassifier().isEmpty()) {
+            sb.append(':').append(artifact.getClassifier());
+        }
+        return sb.append(':').append(artifact.getVersion()).toString();
+    }
+
+    private org.eclipse.aether.artifact.Artifact resolveEpisodeArtifact(final EpisodeArtifact episode)
+            throws MojoExecutionException {
+
+        final String type = episode.getType() == null || episode.getType().isEmpty() ? "jar" : episode.getType();
+
+        final org.eclipse.aether.artifact.Artifact artifact = new DefaultArtifact(
+                episode.getGroupId(), episode.getArtifactId(), episode.getClassifier(), type, episode.getVersion());
+
+        final ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact(artifact);
+        request.setRepositories(remoteProjectRepositories);
+
+        try {
+            final ArtifactResult result = repositorySystem.resolveArtifact(repositorySystemSession, request);
+            final File artifactFile = result.getArtifact().getFile();
+            if (artifactFile == null || !artifactFile.isFile()) {
+                throw new MojoExecutionException("Resolved JAXB episode artifact " + episode.getCoordinate()
+                        + " has no readable local file: " + result.getArtifact());
+            }
+            return result.getArtifact();
+        } catch (final ArtifactResolutionException e) {
+            throw new MojoExecutionException(
+                    "Could not resolve JAXB episode artifact " + episode.getCoordinate()
+                            + ". Declare it as a regular <dependency> as well, so the generated code can compile "
+                            + "against the reused JAXB model.",
+                    e);
+        }
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojo.java
@@ -278,7 +278,7 @@ public abstract class AbstractXsdGeneratorMojo extends AbstractJaxbMojo {
      * {@inheritDoc}
      */
     @Override
-    protected boolean isReGenerationRequired() {
+    protected boolean isReGenerationRequired() throws MojoExecutionException {
 
         final File outputDir = getOutputDirectory();
         if (!FileSystemUtilities.containsFiles(outputDir)) {

--- a/src/site/markdown/example_xjc_episodes.md
+++ b/src/site/markdown/example_xjc_episodes.md
@@ -1,0 +1,150 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+Modular JAXB compilation with dependency episodes
+==============================================-->
+
+When several Maven modules compile schemas that reference each other's namespaces, each module
+would normally re-generate Java classes for the shared namespace. A JAXB *episode* file tells
+XJC that the types of a given namespace already have Java bindings elsewhere, so downstream
+modules re-use the upstream model classes instead of generating duplicates.
+
+Since plugin version `4.1.1`, the `xjc` goal can resolve episode files directly from Maven
+dependency artifacts, comparable to the `episodes` configuration of other JAXB plugins.
+
+Producer module: generating an episode
+--------------------------------------
+
+Have the upstream module generate its model classes and an episode file. The episode is written
+to `META-INF/JAXB/<episodeFileName>.xjb` beneath the `outputDirectory` and packaged into the
+module's JAR:
+
+```xml
+<plugin>
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jaxb2-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>generate-a</id>
+      <goals>
+        <goal>xjc</goal>
+      </goals>
+      <configuration>
+        <packageName>com.example.a</packageName>
+        <episodeFileName>schema-a-episode</episodeFileName>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+Consumer module: resolving episodes from dependencies
+-----------------------------------------------------
+
+Declare the upstream artifact as a regular dependency (the generated code compiles against
+the re-used classes), and reference it within the `episodes` parameter:
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-episode-schema-a</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </dependency>
+</dependencies>
+
+<plugin>
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jaxb2-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>generate-b</id>
+      <goals>
+        <goal>xjc</goal>
+      </goals>
+      <configuration>
+        <packageName>com.example.b</packageName>
+        <episodes>
+          <episode>
+            <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+            <artifactId>xjc-episode-schema-a</artifactId>
+            <version>1.0-SNAPSHOT</version>
+          </episode>
+        </episodes>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+Episode discovery order
+-----------------------
+
+Within each episode artifact, exactly one episode resource is selected using this order:
+
+1. An explicit `<resourcePath>` within the `<episode>` element, when configured.
+2. `META-INF/sun-jaxb.episode` (the JAXB reference implementation convention).
+3. `META-INF/JAXB/sun-jaxb.episode.xjb`.
+4. The single `*.xjb` file directly within `META-INF/JAXB/` (the location produced by this
+   plugin), provided exactly one candidate exists.
+
+An explicit episode whose artifact contains no episode resource fails the build, unless
+`<optional>true</optional>` is configured. If multiple candidate episodes exist, the build
+fails and lists the candidates; resolve the ambiguity by configuring `<resourcePath>`.
+
+The selected episode resource is extracted beneath
+`${project.build.directory}/jaxb2/episodes/` in a deterministic
+`groupId/artifactId/version` layout, preserving the source entry's timestamp so that
+incremental builds re-run XJC only when the episode artifact changes.
+
+Scanning dependencies automatically
+-----------------------------------
+
+For projects where every dependency is deliberately a schema model artifact, explicit
+declarations can be replaced by a scan of the project's dependencies:
+
+```xml
+<configuration>
+  <useDependenciesAsEpisodes>true</useDependenciesAsEpisodes>
+  <!-- Optional: also scan transitive dependencies. Default false. -->
+  <includeTransitiveEpisodes>false</includeTransitiveEpisodes>
+</configuration>
+```
+
+Dependencies without episode resources are ignored. By default only direct dependencies in
+the `compile` or `runtime` scopes are scanned.
+
+Configuration reference
+-----------------------
+
+|          Parameter           |                   Default                   |                         Description                          |
+|------------------------------|---------------------------------------------|--------------------------------------------------------------|
+| `episodes`                   | none                                        | Explicit episode artifacts, resolved through Maven Resolver. |
+| `useDependenciesAsEpisodes`  | `false`                                     | Scan eligible project dependencies for episode resources.    |
+| `includeTransitiveEpisodes`  | `false`                                     | Include transitive dependencies in the scan.                 |
+| `episodeExtractionDirectory` | `${project.build.directory}/jaxb2/episodes` | Root directory for materialized episode files.               |
+
+Each `<episode>` element supports `groupId`, `artifactId`, `version` (all required), `type`
+(default `jar`), `classifier`, `resourcePath`, and `optional` (default `false`).
+
+Limitations
+-----------
+
+An episode only prevents duplicate Java class generation. The imported XSD documents
+themselves must still be resolvable by XJC - through a regular `schemaLocation`, an XML
+catalog, or an unpack step.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -29,6 +29,7 @@ under the License.
         </menu>
         <menu name="Examples">
             <item name="XJC: Usage" href="example_xjc_basic.html"/>
+            <item name="XJC: Dependency Episodes" href="example_xjc_episodes.html"/>
             <item name="Schemagen: Usage" href="example_schemagen_basic.html"/>
             <item name="Schemagen: Post-processing" href="example_schemagen_postprocessing.html"/>
         </menu>

--- a/src/test/java/org/codehaus/mojo/jaxb2/EpisodeFileTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/EpisodeFileTest.java
@@ -50,7 +50,7 @@ class EpisodeFileTest {
         }
 
         @Override
-        protected boolean isReGenerationRequired() {
+        protected boolean isReGenerationRequired() throws MojoExecutionException {
             return false;
         }
 

--- a/src/test/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojoTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.settings.Settings;
 import org.codehaus.mojo.jaxb2.BufferingLog;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +71,7 @@ class AbstractJavaGeneratorMojoTest {
         }
 
         @Override
-        protected List<File> getSourceXJBs() {
+        protected List<File> getSourceXJBs() throws MojoExecutionException {
             return xjbFiles;
         }
 
@@ -141,7 +142,7 @@ class AbstractJavaGeneratorMojoTest {
     }
 
     @Test
-    void validateReGenerationRequiredWhenOutputDirDoesNotExist(@TempDir final File tempDir) {
+    void validateReGenerationRequiredWhenOutputDirDoesNotExist(@TempDir final File tempDir) throws Exception {
         mojo.setOutputDirectory(new File(tempDir, "does-not-exist"));
         mojo.setStaleFileDirectory(tempDir);
 
@@ -149,7 +150,7 @@ class AbstractJavaGeneratorMojoTest {
     }
 
     @Test
-    void validateReGenerationRequiredWhenOutputDirIsEmpty(@TempDir final File tempDir) {
+    void validateReGenerationRequiredWhenOutputDirIsEmpty(@TempDir final File tempDir) throws Exception {
         final File emptyOutDir = new File(tempDir, "emptyOutput");
         assertTrue(emptyOutDir.mkdirs());
         mojo.setOutputDirectory(emptyOutDir);
@@ -159,7 +160,8 @@ class AbstractJavaGeneratorMojoTest {
     }
 
     @Test
-    void validateReGenerationRequiredWhenOutputDirHasOnlyEmptySubdirectories(@TempDir final File tempDir) {
+    void validateReGenerationRequiredWhenOutputDirHasOnlyEmptySubdirectories(@TempDir final File tempDir)
+            throws Exception {
         final File emptyOutDir = new File(tempDir, "nestedEmpty/sub/pkg");
         assertTrue(emptyOutDir.mkdirs());
         mojo.setOutputDirectory(new File(tempDir, "nestedEmpty"));

--- a/src/test/java/org/codehaus/mojo/jaxb2/javageneration/EpisodeJarSupportTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/javageneration/EpisodeJarSupportTest.java
@@ -1,0 +1,217 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EpisodeJarSupportTest {
+
+    @TempDir
+    File tempDir;
+
+    private File jarFile;
+
+    @BeforeEach
+    void createJar() throws IOException {
+        jarFile = new File(tempDir, "fixture.jar");
+    }
+
+    private void writeJar(final String... entries) throws IOException {
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile))) {
+            for (String entry : entries) {
+                final JarEntry jarEntry = new JarEntry(entry);
+                jarEntry.setTime(1_000_000L);
+                jos.putNextEntry(jarEntry);
+                jos.write(("<" + entry + "/>").getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                jos.closeEntry();
+            }
+        }
+    }
+
+    @Test
+    void validateStandardEpisodeResourceDiscoveredFirst() throws Exception {
+        writeJar("META-INF/sun-jaxb.episode", "META-INF/JAXB/sun-jaxb.episode.xjb", "com/acme/A.class");
+
+        assertEquals("META-INF/sun-jaxb.episode", EpisodeJarSupport.selectEpisodeEntry(jarFile, null, "g:a:jar:1"));
+    }
+
+    @Test
+    void validateMojohausLocationDiscoveredSecond() throws Exception {
+        writeJar("META-INF/JAXB/sun-jaxb.episode.xjb", "com/acme/A.class");
+
+        assertEquals(
+                "META-INF/JAXB/sun-jaxb.episode.xjb", EpisodeJarSupport.selectEpisodeEntry(jarFile, null, "g:a:jar:1"));
+    }
+
+    @Test
+    void validateSingleMojohausEpisodeDiscovered() throws Exception {
+        writeJar("META-INF/JAXB/episode_generate-a.xjb", "com/acme/A.class");
+
+        assertEquals(
+                "META-INF/JAXB/episode_generate-a.xjb",
+                EpisodeJarSupport.selectEpisodeEntry(jarFile, null, "g:a:jar:1"));
+    }
+
+    @Test
+    void validateAmbiguousMojohausEpisodesFail() throws Exception {
+        writeJar("META-INF/JAXB/episode_core.xjb", "META-INF/JAXB/episode_ext.xjb");
+
+        final MojoExecutionException e = assertThrows(
+                MojoExecutionException.class, () -> EpisodeJarSupport.selectEpisodeEntry(jarFile, null, "g:a:jar:1"));
+
+        assertTrue(e.getMessage().contains("Multiple JAXB episode resources"));
+        assertTrue(e.getMessage().contains("episode_core.xjb"));
+        assertTrue(e.getMessage().contains("episode_ext.xjb"));
+    }
+
+    @Test
+    void validateMissingEpisodeYieldsNull() throws Exception {
+        writeJar("com/acme/A.class", "META-INF/MANIFEST.MF");
+
+        assertNull(EpisodeJarSupport.selectEpisodeEntry(jarFile, null, "g:a:jar:1"));
+    }
+
+    @Test
+    void validateExplicitResourcePathSelected() throws Exception {
+        writeJar("META-INF/sun-jaxb.episode", "custom/episode.xjb");
+
+        assertEquals(
+                "custom/episode.xjb", EpisodeJarSupport.selectEpisodeEntry(jarFile, "custom/episode.xjb", "g:a:jar:1"));
+    }
+
+    @Test
+    void validateExplicitResourcePathMustExist() throws Exception {
+        writeJar("META-INF/sun-jaxb.episode");
+
+        final MojoExecutionException e = assertThrows(
+                MojoExecutionException.class,
+                () -> EpisodeJarSupport.selectEpisodeEntry(jarFile, "does/not/exist.xjb", "g:a:jar:1"));
+
+        assertTrue(e.getMessage().contains("does not exist within artifact"));
+    }
+
+    @Test
+    void validateNonJarArtifactFails() {
+        final MojoExecutionException e = assertThrows(
+                MojoExecutionException.class,
+                () -> EpisodeJarSupport.selectEpisodeEntry(new File(tempDir, "missing.jar"), null, "g:a:jar:1"));
+
+        assertTrue(e.getMessage().contains("is not a readable file"));
+    }
+
+    @Test
+    void validateExtractionProducesTimestampedFile() throws Exception {
+        writeJar("META-INF/JAXB/episode_generate-a.xjb");
+        final Path extractionRoot = Files.createTempDirectory(tempDir.toPath(), "extract");
+
+        final File extracted = EpisodeJarSupport.extractEpisodeEntry(
+                jarFile, "META-INF/JAXB/episode_generate-a.xjb", extractionRoot, "com.acme", "schema-a", "1.4.0");
+
+        assertTrue(extracted.exists());
+        assertEquals(
+                new File(extractionRoot.toFile(), "com.acme/schema-a/1.4.0/META-INF/JAXB/episode_generate-a.xjb"),
+                extracted);
+        assertEquals(1_000_000L, extracted.lastModified());
+    }
+
+    @Test
+    void validateExtractionRejectsPathTraversal() throws Exception {
+        // Build a JAR whose entry name attempts to escape the extraction root.
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile))) {
+            final JarEntry evil = new JarEntry("../../evil.xjb");
+            evil.setTime(1_000L);
+            jos.putNextEntry(evil);
+            jos.write("evil".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        final MojoExecutionException e = assertThrows(
+                MojoExecutionException.class,
+                () -> EpisodeJarSupport.extractEpisodeEntry(
+                        jarFile,
+                        "../../evil.xjb",
+                        Files.createTempDirectory(tempDir.toPath(), "extract2"),
+                        "g",
+                        "a",
+                        "1"));
+        assertNotNull(e);
+    }
+
+    @Test
+    void validateExtractedContentMatchesEntry() throws Exception {
+        writeJar("META-INF/JAXB/episode_generate-a.xjb");
+        final File extracted = EpisodeJarSupport.extractEpisodeEntry(
+                jarFile,
+                "META-INF/JAXB/episode_generate-a.xjb",
+                Files.createTempDirectory(tempDir.toPath(), "extract3"),
+                "com.acme",
+                "schema-a",
+                "1.4.0");
+
+        assertEquals(
+                "<META-INF/JAXB/episode_generate-a.xjb/>",
+                new String(Files.readAllBytes(extracted.toPath()), java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void validateEpisodeArtifactCoordinate() {
+        final EpisodeArtifact episode = new EpisodeArtifact();
+        episode.setGroupId("com.acme.schemas");
+        episode.setArtifactId("schema-a");
+        episode.setVersion("1.4.0");
+
+        assertEquals("com.acme.schemas:schema-a:jar:1.4.0", episode.getCoordinate());
+
+        episode.setClassifier("schemas");
+        assertEquals("com.acme.schemas:schema-a:jar:schemas:1.4.0", episode.getCoordinate());
+    }
+
+    @Test
+    void validateEpisodeArtifactValidation() {
+        final EpisodeArtifact episode = new EpisodeArtifact();
+        assertThrows(NullPointerException.class, episode::validate);
+
+        episode.setGroupId("g");
+        assertThrows(NullPointerException.class, episode::validate);
+
+        episode.setArtifactId("a");
+        assertThrows(NullPointerException.class, episode::validate);
+
+        episode.setVersion("1");
+        episode.validate();
+    }
+}

--- a/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/schemageneration/AbstractXsdGeneratorMojoTest.java
@@ -107,7 +107,7 @@ class AbstractXsdGeneratorMojoTest {
     }
 
     @Test
-    void validateReGenerationRequiredWhenOutputDirDoesNotExist(@TempDir final File tempDir) {
+    void validateReGenerationRequiredWhenOutputDirDoesNotExist(@TempDir final File tempDir) throws Exception {
         mojo.setOutputDirectory(new File(tempDir, "does-not-exist"));
         mojo.setStaleFileDirectory(tempDir);
 
@@ -115,7 +115,7 @@ class AbstractXsdGeneratorMojoTest {
     }
 
     @Test
-    void validateReGenerationRequiredWhenOutputDirIsEmpty(@TempDir final File tempDir) {
+    void validateReGenerationRequiredWhenOutputDirIsEmpty(@TempDir final File tempDir) throws Exception {
         final File emptyOutDir = new File(tempDir, "emptyOutput");
         assertTrue(emptyOutDir.mkdirs());
         mojo.setOutputDirectory(emptyOutDir);


### PR DESCRIPTION
### Summary

Implements first-class **dependency episode support** for the `xjc` goal, fixing #234 and bringing the plugin to parity with `org.jvnet.jaxb:jaxb-maven-plugin`'s `<episodes>` feature for the most common modular-compilation workflows.

An upstream schema module generates its model classes and episode file; a downstream module references the upstream **artifact** and the plugin resolves its episode from the Maven dependency graph, materializes it locally and passes it to XJC as an external binding — so downstream modules **re-use** upstream model classes instead of generating duplicates.

```xml
<episodes>
  <episode>
    <groupId>com.acme.schemas</groupId>
    <artifactId>schema-a</artifactId>
    <version>1.4.0</version>
  </episode>
</episodes>
```

### Design highlights

- **Modern Maven Resolver** — explicit episode artifacts are resolved via `org.eclipse.aether.RepositorySystem` (JSR-330 `@Inject`, `RepositorySystemSession`, `ArtifactRequest`/`ArtifactResult`). No deprecated `ArtifactResolver`/`ArtifactRepository` APIs. Auto-discovery mode inspects the already-resolved project graph (`project.getArtifacts()`) without re-resolving.
- **Deterministic discovery contract** — per artifact: explicit `resourcePath` → `META-INF/sun-jaxb.episode` → `META-INF/JAXB/sun-jaxb.episode.xjb` → single `META-INF/JAXB/*.xjb` candidate. Ambiguity fails with a listing of candidates and a suggested fix; explicit-but-missing fails unless `<optional>true</optional>`.
- **Incremental-build correctness** — extracted episodes preserve the source JAR entry's timestamp, so the existing stale-file mechanism re-runs XJC only when the episode artifact actually changes.
- **Deterministic ordering** — local `xjbSources`, then explicit episodes (declaration order), then discovered episodes (coordinate order). Duplicated artifact+entry selections are de-duplicated.
- **Safety** — ZIP-slip protection (rejects `..`/absolute entry names and verifies the extraction target stays beneath the extraction root); reactor artifacts that are not yet packaged produce an actionable error.
- **Scope** — `useDependenciesAsEpisodes` defaults to `false`; only direct `compile`/`runtime` dependencies are scanned unless `includeTransitiveEpisodes=true`. Ordinary dependencies without episodes are skipped at debug level.
- Explicit episodes do **not** implicitly add classpath dependencies — users declare the artifact under `<dependencies>` too, so mediation/dependencyManagement/SBOM tooling stays authoritative (an actionable hint is included in resolution failures).

### Testing

- 13 new unit tests for discovery order, ambiguity, missing/optional handling, explicit resource paths, extraction layout, entry-timestamp preservation, ZIP-slip rejection and `EpisodeArtifact` validation/co-ordinates.
- New multi-module invoker IT **`xjc-episode-from-dependencies`** (`clean install`): module A packages its episode; module B imports A's namespace, declares A in `<episodes>`, and verify asserts that (1) A's JAR contains the episode, (2) B's own classes are generated, (3) B does **not** regenerate A's classes, (4) B's sources reference A's types, (5) the episode was extracted to the deterministic layout, (6) the mojo logs the resolution.
- Full unit suite green (157 tests); existing ITs (`xjc-main`, `schemagen-main`, `xjc-include-xsds-in-artifact`, `xjc-multiple-executions`) re-verified.

### Documentation

- New site page `example_xjc_episodes.md` (linked from the site menu) covering producer/consumer setup, the discovery contract, scan mode, the configuration reference and the explicit limitation that **episodes do not resolve imported XSDs** — schema resolution via Maven-aware catalogs is the separate, follow-up feature (#264).

Fixes #234