### PR TITLE
Add support for maven: URIs in XML catalogs to resolve XSDs from dependencies (#264)

### DIFF
--- a/src/it/xjc-catalog-maven-uri/consumer/pom.xml
+++ b/src/it/xjc-catalog-maven-uri/consumer/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+        <artifactId>xjc-catalog-maven-uri</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xjc-catalog-consumer</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+            <artifactId>xjc-catalog-schema-lib</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-order</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <catalog>src/main/resources/catalog.xml</catalog>
+                            <packageName>com.example.order</packageName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/xjc-catalog-maven-uri/consumer/src/main/resources/catalog.xml
+++ b/src/it/xjc-catalog-maven-uri/consumer/src/main/resources/catalog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <rewriteSystem systemIdStartString="http://example.com/"
+                   rewritePrefix="maven:org.codehaus.mojo.jaxb2.its:xjc-catalog-schema-lib:jar:!/schemas/"/>
+</catalog>

--- a/src/it/xjc-catalog-maven-uri/consumer/src/main/xsd/order.xsd
+++ b/src/it/xjc-catalog-maven-uri/consumer/src/main/xsd/order.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:addr="http://example.com/address"
+           targetNamespace="http://example.com/order"
+           xmlns:tns="http://example.com/order"
+           elementFormDefault="qualified">
+
+    <!-- Consumer XSD that imports the shared address.xsd from the schema-lib dependency JAR.
+         The xs:import systemId uses the public URL "http://example.com/address.xsd" which is
+         rewritten to the maven: URI in the catalog file, resolved by the jaxb2-maven-plugin
+         to a jar:file:// URL pointing into the schema-lib artifact. -->
+    <xs:import namespace="http://example.com/address"
+               schemaLocation="http://example.com/address.xsd"/>
+
+    <xs:complexType name="OrderType">
+        <xs:sequence>
+            <xs:element name="orderId"          type="xs:string"/>
+            <xs:element name="shippingAddress"  type="addr:AddressType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Order" type="tns:OrderType"/>
+
+</xs:schema>

--- a/src/it/xjc-catalog-maven-uri/invoker.properties
+++ b/src/it/xjc-catalog-maven-uri/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean install

--- a/src/it/xjc-catalog-maven-uri/pom.xml
+++ b/src/it/xjc-catalog-maven-uri/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+    <artifactId>xjc-catalog-maven-uri</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Purpose: Validate that the jaxb2-maven-plugin resolves maven: URIs in XML catalog files
+        by locating the referenced XSD resources inside dependency JARs (Issue #264).
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>schema-lib</module>
+        <module>consumer</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.11.0</version>
+                    <configuration>
+                        <source>11</source>
+                        <target>11</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/xjc-catalog-maven-uri/schema-lib/pom.xml
+++ b/src/it/xjc-catalog-maven-uri/schema-lib/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codehaus.mojo.jaxb2.its</groupId>
+        <artifactId>xjc-catalog-maven-uri</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xjc-catalog-schema-lib</artifactId>
+    <!-- packaging=jar so the XSD in src/main/resources is bundled into the JAR -->
+    <packaging>jar</packaging>
+
+    <description>
+        Schema library module: packages schemas/address.xsd inside its JAR artifact.
+        The consumer module references this XSD via a maven: URI in its XJC catalog.
+    </description>
+</project>

--- a/src/it/xjc-catalog-maven-uri/schema-lib/src/main/resources/schemas/address.xsd
+++ b/src/it/xjc-catalog-maven-uri/schema-lib/src/main/resources/schemas/address.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/address"
+           xmlns:tns="http://example.com/address"
+           elementFormDefault="qualified">
+
+    <!-- Shared address type — packaged inside the schema-lib JAR at schemas/address.xsd.
+         Consumers reference this file via a maven: catalog URI so they do not need to
+         copy or unpack it; the jaxb2-maven-plugin resolves the maven: URI to a jar: URL. -->
+
+    <xs:complexType name="AddressType">
+        <xs:sequence>
+            <xs:element name="street"   type="xs:string"/>
+            <xs:element name="city"     type="xs:string"/>
+            <xs:element name="country"  type="xs:string"/>
+            <xs:element name="postCode" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Address" type="tns:AddressType"/>
+
+</xs:schema>

--- a/src/it/xjc-catalog-maven-uri/verify.groovy
+++ b/src/it/xjc-catalog-maven-uri/verify.groovy
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def log = new File(basedir, "build.log").text
+
+// 1. Check that schema-lib packaged its JAR with the schema
+def libJar = new File(basedir, "schema-lib/target/xjc-catalog-schema-lib-1.0-SNAPSHOT.jar")
+assert libJar.isFile() : "schema-lib JAR not found: " + libJar
+
+// 2. Check that the resolved catalog was generated in target/jaxb2/
+def resolvedCatalog = new File(basedir, "consumer/target/jaxb2/resolved-catalog.xml")
+assert resolvedCatalog.isFile() : "Resolved catalog file not found: " + resolvedCatalog
+
+def resolvedText = resolvedCatalog.text
+assert resolvedText.contains("jar:file:") : "Resolved catalog does not contain jar:file: URL: " + resolvedText
+assert !resolvedText.contains("maven:org.codehaus") : "Resolved catalog still contains unreplaced maven: URI: " + resolvedText
+assert resolvedText.contains("schemas/") : "Resolved catalog does not reference schemas/: " + resolvedText
+
+// 3. Verify that XJC successfully generated classes from both order.xsd and the resolved address.xsd
+def orderType = new File(basedir, "consumer/target/generated-sources/jaxb/com/example/order/OrderType.java")
+assert orderType.isFile() : "OrderType.java was not generated: " + orderType
+
+def addressType = new File(basedir, "consumer/target/generated-sources/jaxb/com/example/order/AddressType.java")
+assert addressType.isFile() : "AddressType.java (from resolved address.xsd) was not generated: " + addressType
+
+def objectFactory = new File(basedir, "consumer/target/generated-sources/jaxb/com/example/order/ObjectFactory.java")
+assert objectFactory.isFile() : "ObjectFactory.java was not generated: " + objectFactory
+
+// 4. Verify OrderType references AddressType
+assert orderType.text.contains("AddressType") : "OrderType does not reference AddressType: " + orderType.text
+
+// 5. Verify resolution was logged
+assert log.contains("Resolving maven: URIs in catalog") : "Log missing catalog resolution message"
+assert log.contains("Resolved catalog written to") : "Log missing resolved catalog written message"

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/AbstractJavaGeneratorMojo.java
@@ -637,6 +637,24 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
      */
     protected abstract List<File> getSourceXJBs() throws MojoExecutionException;
 
+    /**
+     * Optionally pre-processes the supplied catalog {@link File} before it is passed to XJC.
+     *
+     * <p>The default implementation returns {@code catalogFile} unchanged. Subclasses (such as
+     * {@code XjcMojo}) can override this method to resolve {@code maven:} URIs in the catalog to
+     * concrete {@code jar:file://} URLs, allowing XJC to consume XSD resources packaged inside
+     * Maven dependency JARs without manual unpacking.</p>
+     *
+     * @param catalogFile the catalog file as configured by the user; never {@code null}
+     * @return the catalog file to pass to XJC — either {@code catalogFile} as-is, or a rewritten
+     *         copy written to the build directory
+     * @throws MojoExecutionException if catalog pre-processing fails
+     */
+    protected File resolveCatalog(final File catalogFile) throws MojoExecutionException {
+        // Default: no pre-processing. Subclasses may override to resolve maven: URIs.
+        return catalogFile;
+    }
+
     //
     // Private helpers
     //
@@ -689,7 +707,10 @@ public abstract class AbstractJavaGeneratorMojo extends AbstractJaxbMojo {
         }
 
         if (catalog != null) {
-            builder.withNamedArgument("catalog", FileSystemUtilities.getCanonicalPath(catalog));
+            // Allow subclasses (e.g. XjcMojo) to pre-process the catalog before handing it to XJC.
+            // The default implementation returns the file unchanged; XjcMojo resolves maven: URIs.
+            final File effectiveCatalog = resolveCatalog(catalog);
+            builder.withNamedArgument("catalog", FileSystemUtilities.getCanonicalPath(effectiveCatalog));
         }
 
         if (plugins != null) {

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/MavenUriCatalogResolver.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/MavenUriCatalogResolver.java
@@ -1,0 +1,360 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+/**
+ * Pre-processes an OASIS XML Catalog file by resolving {@code maven:} URIs into
+ * concrete {@code jar:file://} URLs backed by artifacts in the local Maven repository.
+ *
+ * <h2>The {@code maven:} URI scheme</h2>
+ * <p>The scheme follows the format used by the
+ * <a href="https://github.com/highsource/jaxb-tools">jaxb-tools</a> project:</p>
+ * <pre>
+ *   maven:groupId:artifactId:type:classifier!/path/in/jar
+ * </pre>
+ * <p>Examples:</p>
+ * <ul>
+ *   <li>{@code maven:com.example:shared-schemas:jar:!/schemas/common.xsd}</li>
+ *   <li>{@code maven:com.example:shared-schemas:jar::!/schemas/common.xsd} (empty classifier)</li>
+ *   <li>{@code maven:com.example:shared-schemas:jar!/schemas/common.xsd} (omit classifier segment)</li>
+ * </ul>
+ *
+ * <h2>Resolution</h2>
+ * <p>Each {@code maven:} URI is resolved via the Aether {@link RepositorySystem} to obtain the
+ * artifact's local file. The resolved URI becomes a {@code jar:file:///…!/path/in/jar} URL that
+ * XJC's built-in catalog support can follow without any further custom resolver.</p>
+ *
+ * <h2>Catalog pre-processing</h2>
+ * <p>The original catalog file is read, all {@code maven:…} occurrences are replaced, and the
+ * result is written to a new file in the build directory. The new file path is returned and used
+ * as the catalog argument to XJC in place of the original.</p>
+ *
+ * @since 4.1.1
+ */
+public final class MavenUriCatalogResolver {
+
+    /**
+     * Regex that matches a {@code maven:} URI anywhere in a catalog file line.
+     *
+     * <p>The captured groups are:</p>
+     * <ol>
+     *   <li>groupId</li>
+     *   <li>artifactId</li>
+     *   <li>type (may be empty → defaults to {@code jar})</li>
+     *   <li>classifier (optional segment after the third colon; may be absent or empty)</li>
+     *   <li>path-in-jar (after {@code !/})</li>
+     * </ol>
+     *
+     * <p>Supported formats:</p>
+     * <ul>
+     *   <li>{@code maven:g:a:jar:cls!/path} — four-segment, explicit classifier</li>
+     *   <li>{@code maven:g:a:jar:!/path} — four-segment, empty classifier</li>
+     *   <li>{@code maven:g:a:jar!/path} — three-segment, no classifier</li>
+     *   <li>{@code maven:g:a!/path} — two-segment, defaults type=jar, no classifier</li>
+     * </ul>
+     */
+    static final Pattern MAVEN_URI_PATTERN = Pattern.compile(
+            // scheme + groupId:artifactId
+            "maven:([^:!/]+):([^:!/]+)"
+                    // optional :type
+                    + "(?::([^:!/]*))?"
+                    // optional :classifier
+                    + "(?::([^:!/]*))?"
+                    // !/ separator and path-in-jar
+                    + "!(/[^\"' \\t>]*)");
+
+    private final RepositorySystem repositorySystem;
+    private final RepositorySystemSession session;
+    private final List<RemoteRepository> remoteRepositories;
+    private final Log log;
+
+    /**
+     * Creates a new resolver.
+     *
+     * @param repositorySystem   Aether repository system, injected by the mojo
+     * @param session            the current repository system session
+     * @param remoteRepositories the project's remote repositories
+     * @param log                the Maven build log
+     */
+    public MavenUriCatalogResolver(
+            final RepositorySystem repositorySystem,
+            final RepositorySystemSession session,
+            final List<RemoteRepository> remoteRepositories,
+            final Log log) {
+        this.repositorySystem = repositorySystem;
+        this.session = session;
+        this.remoteRepositories = remoteRepositories;
+        this.log = log;
+    }
+
+    /**
+     * Returns {@code true} if the given catalog file text contains at least one {@code maven:} URI.
+     *
+     * <p>Used as a fast-path guard: catalogs without {@code maven:} references are passed straight
+     * to XJC without any pre-processing.</p>
+     *
+     * @param catalogText the full text of the catalog file
+     * @return {@code true} when a {@code maven:…!/…} pattern is present
+     */
+    public static boolean containsMavenUris(final String catalogText) {
+        return MAVEN_URI_PATTERN.matcher(catalogText).find();
+    }
+
+    /**
+     * Reads {@code originalCatalog}, resolves all {@code maven:} URIs within it to
+     * {@code jar:file://} URLs, and writes the result to {@code resolvedCatalog}.
+     *
+     * <p>If the catalog does not contain any {@code maven:} URIs this method simply returns
+     * {@code originalCatalog} without touching the filesystem.</p>
+     *
+     * @param originalCatalog the user-supplied catalog file
+     * @param resolvedCatalog the target file for the pre-processed catalog in the build directory
+     * @return {@code resolvedCatalog} when any {@code maven:} URIs were found and replaced,
+     *         or {@code originalCatalog} if the file contained no {@code maven:} URIs
+     * @throws MojoExecutionException if an artifact cannot be resolved or the file cannot be written
+     */
+    public File resolve(final File originalCatalog, final File resolvedCatalog) throws MojoExecutionException {
+
+        final String originalText;
+        try {
+            originalText = new String(Files.readAllBytes(originalCatalog.toPath()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Cannot read catalog file [" + originalCatalog.getAbsolutePath() + "]", e);
+        }
+
+        // Fast path: nothing to do when no maven: URIs are present.
+        if (!containsMavenUris(originalText)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Catalog [" + originalCatalog.getName() + "] contains no maven: URIs; "
+                        + "passing it to XJC unchanged.");
+            }
+            return originalCatalog;
+        }
+
+        log.info("Resolving maven: URIs in catalog [" + originalCatalog.getAbsolutePath() + "]");
+
+        // Resolve each unique maven: coordinate to a local jar: URL.
+        // We cache per-coordinate to avoid duplicate Aether round-trips for the same artifact.
+        final Map<String, String> mavenToJarUrl = new LinkedHashMap<>();
+
+        final Matcher m = MAVEN_URI_PATTERN.matcher(originalText);
+        while (m.find()) {
+            final String fullMatch = m.group(0); // the full maven:…!/path token
+            if (mavenToJarUrl.containsKey(fullMatch)) {
+                continue; // already resolved
+            }
+
+            final String groupId = m.group(1);
+            final String artifactId = m.group(2);
+            // group(3) = type segment (may be null or empty → default to "jar")
+            final String type = (m.group(3) == null || m.group(3).isEmpty()) ? "jar" : m.group(3);
+            // group(4) = classifier segment (may be null or empty → no classifier)
+            final String classifier = (m.group(4) == null || m.group(4).isEmpty()) ? "" : m.group(4);
+            // group(5) = path-in-jar (always starts with /)
+            final String pathInJar = m.group(5);
+
+            final String coordinate =
+                    groupId + ":" + artifactId + ":" + type + (classifier.isEmpty() ? "" : ":" + classifier);
+
+            if (log.isDebugEnabled()) {
+                log.debug("  Resolving maven: artifact [" + coordinate + "] for path [" + pathInJar + "]");
+            }
+
+            final File artifactFile = resolveArtifact(groupId, artifactId, type, classifier, coordinate);
+
+            // Produce a jar: URL pointing into the resolved artifact.
+            // We use toURI().toASCIIString() to encode any special characters in the path.
+            final String jarUrl = "jar:" + artifactFile.toURI().toASCIIString() + "!" + pathInJar;
+
+            if (log.isDebugEnabled()) {
+                log.debug("  Resolved [" + fullMatch + "] -> [" + jarUrl + "]");
+            }
+
+            mavenToJarUrl.put(fullMatch, jarUrl);
+        }
+
+        // Replace all maven: tokens with their resolved jar: URLs.
+        String resolvedText = originalText;
+        for (Map.Entry<String, String> entry : mavenToJarUrl.entrySet()) {
+            // Escape the key for regex replacement (it contains : and / which are regex metacharacters).
+            resolvedText = resolvedText.replace(entry.getKey(), entry.getValue());
+        }
+
+        // Write the resolved catalog to the build directory.
+        try {
+            final File parentDir = resolvedCatalog.getParentFile();
+            if (parentDir != null && !parentDir.exists()) {
+                Files.createDirectories(parentDir.toPath());
+            }
+            Files.write(resolvedCatalog.toPath(), resolvedText.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new MojoExecutionException(
+                    "Cannot write resolved catalog to [" + resolvedCatalog.getAbsolutePath() + "]", e);
+        }
+
+        log.info("Resolved catalog written to [" + resolvedCatalog.getAbsolutePath() + "]");
+        return resolvedCatalog;
+    }
+
+    /**
+     * Resolves a single Maven artifact via Aether and returns its local file.
+     *
+     * @param groupId    the artifact group ID
+     * @param artifactId the artifact artifact ID
+     * @param type       the artifact type (e.g. {@code jar})
+     * @param classifier the artifact classifier, or empty string for none
+     * @param coordinate human-readable coordinate for error messages
+     * @return the resolved local artifact file
+     * @throws MojoExecutionException if the artifact cannot be resolved
+     */
+    private File resolveArtifact(
+            final String groupId,
+            final String artifactId,
+            final String type,
+            final String classifier,
+            final String coordinate)
+            throws MojoExecutionException {
+
+        final org.apache.maven.artifact.Artifact projectArtifact =
+                findArtifactFromProject(groupId, artifactId, type, classifier, coordinate);
+
+        // Fast path: if Maven already resolved the artifact file (e.g. from the local repository
+        // or a reactor build module) and it is a regular file on disk, return it directly.
+        if (projectArtifact.getFile() != null && projectArtifact.getFile().isFile()) {
+            return projectArtifact.getFile();
+        }
+
+        // Use null classifier when empty so Aether resolves the artifact without one.
+        final String aetherClassifier = classifier.isEmpty() ? null : classifier;
+
+        final org.eclipse.aether.artifact.Artifact artifact;
+        try {
+            artifact = new DefaultArtifact(groupId, artifactId, aetherClassifier, type, projectArtifact.getVersion());
+        } catch (final IllegalArgumentException e) {
+            throw new MojoExecutionException(
+                    "Invalid artifact coordinate in catalog maven: URI [" + coordinate + "]: " + e.getMessage(), e);
+        }
+
+        if (repositorySystem == null) {
+            throw new MojoExecutionException("Cannot resolve maven: catalog artifact [" + coordinate
+                    + "] because RepositorySystem is null and artifact file has not been materialized.");
+        }
+
+        final ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact(artifact);
+        request.setRepositories(remoteRepositories);
+
+        try {
+            final ArtifactResult result = repositorySystem.resolveArtifact(session, request);
+            final File artifactFile = result.getArtifact().getFile();
+            if (artifactFile == null || !artifactFile.isFile()) {
+                throw new MojoExecutionException("Resolved artifact [" + coordinate + "] has no readable local file.");
+            }
+            return artifactFile;
+        } catch (final ArtifactResolutionException e) {
+            throw new MojoExecutionException(
+                    "Cannot resolve maven: catalog artifact [" + coordinate
+                            + "]. Ensure it is declared as a project dependency.",
+                    e);
+        }
+    }
+
+    /**
+     * Finds an artifact already present in the project's resolved dependency set.
+     *
+     * <p>The {@code maven:} URI scheme does not include a version — the version is inferred from
+     * the project's declared dependencies. This method locates the artifact among the project's
+     * resolved artifacts and returns it so that its file or version can be used.</p>
+     *
+     * @param groupId    the artifact group ID to look up
+     * @param artifactId the artifact artifact ID to look up
+     * @param type       the artifact type
+     * @param classifier the artifact classifier, empty string if none
+     * @param coordinate human-readable coordinate for error messages
+     * @return the matching resolved project artifact
+     * @throws MojoExecutionException if no matching dependency is found
+     */
+    private org.apache.maven.artifact.Artifact findArtifactFromProject(
+            final String groupId,
+            final String artifactId,
+            final String type,
+            final String classifier,
+            final String coordinate)
+            throws MojoExecutionException {
+
+        if (projectArtifacts == null) {
+            throw new MojoExecutionException("Project artifacts have not been provided to MavenUriCatalogResolver. "
+                    + "This is a plugin bug — please report it.");
+        }
+
+        for (final org.apache.maven.artifact.Artifact a : projectArtifacts) {
+            if (!groupId.equals(a.getGroupId())) continue;
+            if (!artifactId.equals(a.getArtifactId())) continue;
+            if (!type.equals(a.getType())) continue;
+            final String aClassifier = a.getClassifier() == null ? "" : a.getClassifier();
+            if (!classifier.equals(aClassifier)) continue;
+
+            return a;
+        }
+
+        throw new MojoExecutionException("No dependency matching the maven: catalog URI [" + coordinate
+                + "] was found among the project's resolved artifacts. "
+                + "Declare the artifact as a <dependency> in your pom.xml so its version "
+                + "is known and its JAR is available in the local repository.");
+    }
+
+    /**
+     * The set of resolved project artifacts, used by {@link #findVersionFromProject} to look up
+     * the version for artifact coordinates that appear in {@code maven:} URIs.
+     */
+    private java.util.Set<org.apache.maven.artifact.Artifact> projectArtifacts;
+
+    /**
+     * Provides the set of resolved project artifacts.
+     *
+     * <p>Must be called before {@link #resolve} when the catalog may contain {@code maven:} URIs.
+     * Typically populated from {@code MavenProject.getArtifacts()} in the calling mojo.</p>
+     *
+     * @param projectArtifacts the resolved artifacts of the current Maven project
+     */
+    public void setProjectArtifacts(final java.util.Set<org.apache.maven.artifact.Artifact> projectArtifacts) {
+        this.projectArtifacts = projectArtifacts;
+    }
+}

--- a/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxb2/javageneration/XjcMojo.java
@@ -649,4 +649,39 @@ public class XjcMojo extends AbstractJavaGeneratorMojo {
     protected void addResource(final Resource resource) {
         getProject().addResource(resource);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>If the supplied catalog file contains {@code maven:groupId:artifactId:type:classifier!/path}
+     * URIs, this override resolves each of them to a {@code jar:file://} URL pointing into the
+     * corresponding artifact in the local Maven repository, then writes a pre-processed copy of the
+     * catalog to {@code ${project.build.directory}/jaxb2/resolved-<name>} and returns that file
+     * to XJC.</p>
+     *
+     * <p>If the catalog contains no {@code maven:} URIs the original file is returned unchanged.</p>
+     *
+     * <p>This allows users to reference XSD files packaged inside dependency JARs from a catalog:</p>
+     * <pre>
+     * REWRITE_SYSTEM "http://example.com/common.xsd"
+     *     "maven:com.example:shared-schemas:jar:!/schemas/common.xsd"
+     * </pre>
+     *
+     * @see MavenUriCatalogResolver
+     * @since 4.1.1
+     */
+    @Override
+    protected File resolveCatalog(final File catalogFile) throws MojoExecutionException {
+        final MavenUriCatalogResolver resolver = new MavenUriCatalogResolver(
+                repositorySystem, repositorySystemSession, remoteProjectRepositories, getLog());
+        // Provide the project's resolved dependency artifacts so the resolver can look up versions.
+        resolver.setProjectArtifacts(getProject().getArtifacts());
+
+        // The resolved catalog lands in the jaxb2 build directory so it is reproducible and never
+        // pollutes the source tree. Preserving the original file extension is required because XJC
+        // and OASIS catalog parsers use the extension (.xml vs .cat) to select the parser format.
+        final File resolvedCatalog =
+                new File(getProject().getBuild().getDirectory(), "jaxb2/resolved-" + catalogFile.getName());
+        return resolver.resolve(catalogFile, resolvedCatalog);
+    }
 }

--- a/src/site/markdown/example_xjc_catalogs.md
+++ b/src/site/markdown/example_xjc_catalogs.md
@@ -1,0 +1,120 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+XML Catalogs and XSDs from Maven Dependencies
+==========================================-->
+
+When XML schemas import other schemas using public URLs or abstract system IDs (such as
+`http://example.com/schemas/common.xsd`), XJC needs to resolve these identifiers to local files
+without accessing the internet during build time.
+
+XML Catalogs (OASIS XML Catalog and TR9401 plain-text formats) map public IDs and system IDs to
+local files.
+
+Since plugin version `4.1.1` (resolving issue #264), the `xjc` goal supports the `maven:` URI scheme
+within catalog files, allowing you to reference XML schemas packaged directly inside Maven dependency
+JARs without unpacking them first. This feature is compatible with the `maven:` scheme originally
+introduced in `highsource/jaxb-tools`.
+
+The `maven:` URI Scheme
+-----------------------
+
+A `maven:` URI has the following structure:
+
+```text
+maven:groupId:artifactId:type:classifier!/path/inside/jar
+```
+
+* **`groupId`**: The Maven group ID of the dependency containing the XSD.
+* **`artifactId`**: The Maven artifact ID.
+* **`type`**: Optional artifact extension/type (defaults to `jar` if omitted).
+* **`classifier`**: Optional artifact classifier (may be omitted or empty).
+* **`path/inside/jar`**: The relative path to the schema file (or directory) inside the artifact JAR.
+
+The version of the artifact is automatically inferred from the project's declared `<dependencies>`.
+
+Example 1: OASIS XML Catalog (`catalog.xml`)
+--------------------------------------------
+
+Map a public schema URL to an XSD inside a dependency JAR using `<system>`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <system systemId="http://example.com/schemas/address.xsd"
+            uri="maven:org.example:shared-schemas:jar:!/schemas/address.xsd"/>
+</catalog>
+```
+
+Or map an entire URL prefix to a directory inside the dependency JAR using `<rewriteSystem>`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <rewriteSystem systemIdStartString="http://example.com/schemas/"
+                   rewritePrefix="maven:org.example:shared-schemas:jar:!/schemas/"/>
+</catalog>
+```
+
+Example 2: TR9401 Plain Text Catalog (`catalog.cat`)
+----------------------------------------------------
+
+```text
+REWRITE_SYSTEM "http://example.com/schemas/" "maven:org.example:shared-schemas:jar:!/schemas/"
+```
+
+Configuring the Plugin in `pom.xml`
+-----------------------------------
+
+1. Declare the artifact containing the XSD as a project `<dependency>`:
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>org.example</groupId>
+    <artifactId>shared-schemas</artifactId>
+    <version>1.0.0</version>
+  </dependency>
+</dependencies>
+```
+
+2. Point the `jaxb2-maven-plugin` to your catalog file:
+
+```xml
+<plugin>
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jaxb2-maven-plugin</artifactId>
+  <version>4.1.1-SNAPSHOT</version>
+  <executions>
+    <execution>
+      <id>xjc</id>
+      <goals>
+        <goal>xjc</goal>
+      </goals>
+      <configuration>
+        <catalog>src/main/resources/catalog.xml</catalog>
+        <packageName>com.example.model</packageName>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+During build execution, the plugin detects the `maven:` URIs, resolves the artifact's local JAR file
+from Maven dependencies, rewrites the catalog to concrete `jar:file://` URLs in
+`${project.build.directory}/jaxb2/resolved-catalog.xml`, and passes the resolved catalog to XJC.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -30,6 +30,7 @@ under the License.
         <menu name="Examples">
             <item name="XJC: Usage" href="example_xjc_basic.html"/>
             <item name="XJC: Dependency Episodes" href="example_xjc_episodes.html"/>
+            <item name="XJC: Catalogs &amp; Dependency XSDs" href="example_xjc_catalogs.html"/>
             <item name="Schemagen: Usage" href="example_schemagen_basic.html"/>
             <item name="Schemagen: Post-processing" href="example_schemagen_postprocessing.html"/>
         </menu>

--- a/src/test/java/org/codehaus/mojo/jaxb2/javageneration/MavenUriCatalogResolverTest.java
+++ b/src/test/java/org/codehaus/mojo/jaxb2/javageneration/MavenUriCatalogResolverTest.java
@@ -1,0 +1,272 @@
+package org.codehaus.mojo.jaxb2.javageneration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.regex.Matcher;
+
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link MavenUriCatalogResolver}.
+ *
+ * <p>These tests cover the {@code maven:} URI pattern matching and the
+ * {@link MavenUriCatalogResolver#containsMavenUris(String)} fast-path check.
+ * Full end-to-end resolution (Aether artifact lookup) is covered by the integration test
+ * {@code xjc-catalog-maven-uri} in {@code src/it/}.</p>
+ */
+class MavenUriCatalogResolverTest {
+
+    // ==================================================================================
+    // containsMavenUris() fast-path tests
+    // ==================================================================================
+
+    /**
+     * Verifies that a catalog text containing a {@code maven:} URI is detected correctly.
+     */
+    @Test
+    void containsMavenUris_returnsTrueWhenMavenUriPresent() {
+        final String catalog = "REWRITE_SYSTEM \"http://example.com/schema.xsd\"\n"
+                + "    \"maven:com.example:shared:jar:!/schemas/schema.xsd\"";
+
+        assertTrue(
+                MavenUriCatalogResolver.containsMavenUris(catalog), "Expected true when catalog contains maven: URI");
+    }
+
+    /**
+     * Verifies that a catalog with only standard URIs returns {@code false}.
+     *
+     * <p>The fast-path check must not trigger for files that already use {@code file://},
+     * {@code http://}, or relative paths — those should be forwarded to XJC without any
+     * pre-processing.</p>
+     */
+    @Test
+    void containsMavenUris_returnsFalseWhenNoMavenUri() {
+        final String catalog =
+                "REWRITE_SYSTEM \"http://example.com/schema.xsd\"\n" + "    \"file:///local/schemas/schema.xsd\"";
+
+        assertFalse(
+                MavenUriCatalogResolver.containsMavenUris(catalog),
+                "Expected false when catalog contains no maven: URI");
+    }
+
+    /**
+     * Verifies that an empty catalog text returns {@code false}.
+     */
+    @Test
+    void containsMavenUris_returnsFalseForEmptyCatalog() {
+        assertFalse(MavenUriCatalogResolver.containsMavenUris(""), "Expected false for empty catalog text");
+    }
+
+    // ==================================================================================
+    // MAVEN_URI_PATTERN matching tests
+    // ==================================================================================
+
+    /**
+     * Verifies that the four-segment {@code maven:g:a:type:classifier!/path} form is parsed.
+     *
+     * <p>This is the most common form used by jaxb-tools-compatible catalog files.</p>
+     */
+    @Test
+    void pattern_matchesFourSegmentWithClassifier() {
+        // Assemble: full four-segment coordinate
+        final String uri = "maven:com.example:shared-schemas:jar:sources!/schemas/common.xsd";
+
+        // Act
+        final Matcher m = MavenUriCatalogResolver.MAVEN_URI_PATTERN.matcher(uri);
+        assertTrue(m.find(), "Expected pattern to match");
+
+        // Assert
+        assertEquals("com.example", m.group(1), "groupId");
+        assertEquals("shared-schemas", m.group(2), "artifactId");
+        assertEquals("jar", m.group(3), "type");
+        assertEquals("sources", m.group(4), "classifier");
+        assertEquals("/schemas/common.xsd", m.group(5), "path-in-jar");
+    }
+
+    /**
+     * Verifies that the form with an empty classifier segment is matched.
+     *
+     * <p>Empty classifier: {@code maven:g:a:jar:!/path} — the segment exists but is blank.</p>
+     */
+    @Test
+    void pattern_matchesFourSegmentWithEmptyClassifier() {
+        final String uri = "maven:com.example:shared:jar:!/schemas/data.xsd";
+
+        final Matcher m = MavenUriCatalogResolver.MAVEN_URI_PATTERN.matcher(uri);
+        assertTrue(m.find(), "Expected pattern to match");
+
+        assertEquals("com.example", m.group(1));
+        assertEquals("shared", m.group(2));
+        assertEquals("jar", m.group(3));
+        // group(4) is empty string (classifier segment present but empty)
+        assertTrue(m.group(4) == null || m.group(4).isEmpty(), "classifier should be empty");
+        assertEquals("/schemas/data.xsd", m.group(5));
+    }
+
+    /**
+     * Verifies that the three-segment form without a classifier is matched.
+     *
+     * <p>Three-segment: {@code maven:g:a:type!/path}</p>
+     */
+    @Test
+    void pattern_matchesThreeSegmentNoClassifier() {
+        final String uri = "maven:org.example:api-schemas:jar!/xsd/api.xsd";
+
+        final Matcher m = MavenUriCatalogResolver.MAVEN_URI_PATTERN.matcher(uri);
+        assertTrue(m.find(), "Expected pattern to match");
+
+        assertEquals("org.example", m.group(1));
+        assertEquals("api-schemas", m.group(2));
+        assertEquals("jar", m.group(3));
+        // group(4) absent (classifier segment omitted entirely)
+        assertTrue(m.group(4) == null || m.group(4).isEmpty(), "classifier should be absent");
+        assertEquals("/xsd/api.xsd", m.group(5));
+    }
+
+    /**
+     * Verifies that a plain string with no {@code maven:} URI does NOT match.
+     */
+    @Test
+    void pattern_doesNotMatchNonMavenUri() {
+        final String text = "REWRITE_SYSTEM \"http://schemas.example.com/v1/types.xsd\" \"file:///local/types.xsd\"";
+
+        final Matcher m = MavenUriCatalogResolver.MAVEN_URI_PATTERN.matcher(text);
+        assertFalse(m.find(), "Expected no match for non-maven URI text");
+    }
+
+    /**
+     * Verifies that multiple {@code maven:} URIs in the same catalog text are all matched.
+     */
+    @Test
+    void pattern_matchesMultipleMavenUrisInSameText() {
+        final String catalog = "REWRITE_SYSTEM \"http://a.example.com/a.xsd\"\n"
+                + "    \"maven:com.example:module-a:jar:!/xsd/a.xsd\"\n"
+                + "REWRITE_SYSTEM \"http://b.example.com/b.xsd\"\n"
+                + "    \"maven:com.example:module-b:jar:!/xsd/b.xsd\"";
+
+        final Matcher m = MavenUriCatalogResolver.MAVEN_URI_PATTERN.matcher(catalog);
+
+        // First match
+        assertTrue(m.find(), "Expected first match");
+        assertEquals("module-a", m.group(2), "First artifactId");
+        assertEquals("/xsd/a.xsd", m.group(5), "First path");
+
+        // Second match
+        assertTrue(m.find(), "Expected second match");
+        assertEquals("module-b", m.group(2), "Second artifactId");
+        assertEquals("/xsd/b.xsd", m.group(5), "Second path");
+
+        // No more matches
+        assertFalse(m.find(), "Expected no further matches");
+    }
+
+    // ==================================================================================
+    // resolve() tests
+    // ==================================================================================
+
+    @Test
+    void resolve_returnsOriginalCatalogWhenNoMavenUrisPresent(@TempDir final Path tempDir)
+            throws IOException, MojoExecutionException {
+        final File originalCatalog = tempDir.resolve("catalog.xml").toFile();
+        final File resolvedCatalog = tempDir.resolve("catalog-resolved.cat").toFile();
+
+        final String content = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n"
+                + "  <system systemId=\"http://example.com/schema.xsd\" uri=\"schema.xsd\"/>\n"
+                + "</catalog>";
+        Files.write(originalCatalog.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        final MavenUriCatalogResolver resolver =
+                new MavenUriCatalogResolver(null, null, Collections.emptyList(), new SystemStreamLog());
+
+        final File result = resolver.resolve(originalCatalog, resolvedCatalog);
+
+        assertSame(originalCatalog, result, "Should return original file when no maven: URIs exist");
+        assertFalse(resolvedCatalog.exists(), "Resolved catalog should not be created");
+    }
+
+    @Test
+    void resolve_replacesMavenUrisWithJarUrls(@TempDir final Path tempDir) throws IOException, MojoExecutionException {
+        final File dummyJar = tempDir.resolve("my-lib-1.0.jar").toFile();
+        Files.write(dummyJar.toPath(), "PK dummy zip".getBytes(StandardCharsets.UTF_8));
+
+        final DefaultArtifact artifact = new DefaultArtifact(
+                "com.example", "my-lib", "1.0", "compile", "jar", "", new DefaultArtifactHandler("jar"));
+        artifact.setFile(dummyJar);
+
+        final File originalCatalog = tempDir.resolve("catalog.cat").toFile();
+        final File resolvedCatalog =
+                tempDir.resolve("sub/dir/catalog-resolved.cat").toFile();
+
+        final String content = "REWRITE_SYSTEM \"http://example.com/address.xsd\" "
+                + "\"maven:com.example:my-lib:jar:!/schemas/address.xsd\"\n";
+        Files.write(originalCatalog.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        final MavenUriCatalogResolver resolver =
+                new MavenUriCatalogResolver(null, null, Collections.emptyList(), new SystemStreamLog());
+        resolver.setProjectArtifacts(Collections.singleton(artifact));
+
+        final File result = resolver.resolve(originalCatalog, resolvedCatalog);
+
+        assertEquals(resolvedCatalog, result);
+        assertTrue(resolvedCatalog.exists(), "Resolved catalog should be written");
+
+        final String resultText = new String(Files.readAllBytes(resolvedCatalog.toPath()), StandardCharsets.UTF_8);
+        assertFalse(resultText.contains("maven:"), "Should not contain maven: scheme");
+        assertTrue(
+                resultText.contains("jar:" + dummyJar.toURI().toASCIIString() + "!/schemas/address.xsd"),
+                "Should contain resolved jar: URL");
+    }
+
+    @Test
+    void resolve_throwsExceptionWhenDependencyNotFound(@TempDir final Path tempDir) throws IOException {
+        final File originalCatalog = tempDir.resolve("catalog.cat").toFile();
+        final File resolvedCatalog = tempDir.resolve("catalog-resolved.cat").toFile();
+
+        final String content = "REWRITE_SYSTEM \"http://example.com/address.xsd\" "
+                + "\"maven:com.unknown:missing-lib:jar:!/schemas/address.xsd\"\n";
+        Files.write(originalCatalog.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        final MavenUriCatalogResolver resolver =
+                new MavenUriCatalogResolver(null, null, Collections.emptyList(), new SystemStreamLog());
+        resolver.setProjectArtifacts(Collections.emptySet());
+
+        final MojoExecutionException ex =
+                assertThrows(MojoExecutionException.class, () -> resolver.resolve(originalCatalog, resolvedCatalog));
+
+        assertTrue(ex.getMessage().contains("missing-lib"), "Message should mention missing artifact");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #264

Adds the ability to resolve XML schemas packaged inside Maven dependency JARs using the `maven:` URI scheme in catalog files (compatible with the convention introduced in `highsource/jaxb-tools`).

## The `maven:` URI Scheme

In catalog files (OASIS XML Catalog or TR9401 plain text), schemas can be mapped using:
```xml
<rewriteSystem systemIdStartString="http://example.com/schemas/"
               rewritePrefix="maven:groupId:artifactId:type:classifier!/schemas/"/>
```
or exact mapping:
```xml
<system systemId="http://example.com/schemas/address.xsd"
        uri="maven:groupId:artifactId:type:classifier!/schemas/address.xsd"/>
```

## Key Changes

1. **`MavenUriCatalogResolver`**:
   - Matches `maven:groupId:artifactId[:type][:classifier]!/path` patterns in catalog files.
   - Looks up the matching artifact from the project's resolved dependencies.
   - If the artifact's JAR is already resolved (e.g. from local repository or another module in the reactor), it uses that file directly; otherwise falls back to Aether `RepositorySystem`.
   - Rewrites each `maven:` URI to a concrete `jar:file://` URL pointing into the dependency JAR.
   - Writes the resolved catalog to `${project.build.directory}/jaxb2/resolved-<originalName>` (preserving original extension `.xml` or `.cat` for OASIS catalog parser selection).
   - Fast-path check: catalogs without `maven:` URIs are passed to XJC untouched with zero overhead.

2. **`AbstractJavaGeneratorMojo` / `XjcMojo`**:
   - Added protected hook `resolveCatalog(File)` in `AbstractJavaGeneratorMojo` which defaults to no-op.
   - Overridden in `XjcMojo` to pre-process the catalog with `MavenUriCatalogResolver`.

3. **Tests & Documentation**:
   - `MavenUriCatalogResolverTest`: 11 unit tests covering pattern matching, classifier handling, fast-path check, resolution, and error handling for missing dependencies.
   - Integration test `xjc-catalog-maven-uri`: multi-module reactor test verifying a library module packaging an XSD into its JAR, and a consumer module resolving it via `rewriteSystem` with `maven:` URI.
   - User guide: `src/site/markdown/example_xjc_catalogs.md` and linked in `site.xml`.

All 182 unit tests and the integration test pass.