### PR TITLE
Remove explicit maven-resolver-api dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
         versions: [">= 10.0"]
       - dependency-name: "se.jguru.shared.algorithms.api:jguru-shared-algorithms-api"
         versions: [">= 0.13.0"]
+      # Maven Resolver 2.x targets Maven 4
+      - dependency-name: "org.apache.maven.resolver:*"
+        versions: [">= 2.0"]
+      # SLF4J 2.x requires SLF4JServiceProvider, incompatible with Maven 3 runtime
+      - dependency-name: "org.slf4j:*"
+        versions: [">= 2.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -208,12 +208,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-api</artifactId>
-      <version>1.4.1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
## Summary

1. Remove explicit `<dependency>` for `org.apache.maven.resolver:maven-resolver-api:1.4.1` from `pom.xml`.
   The resolver API classes (`org.eclipse.aether.*`) used by `XjcMojo` and `MavenUriCatalogResolver` are already provided transitively via `org.apache.maven:maven-core:${mavenVersion}` (3.6.3):
   ```text
   +- org.apache.maven:maven-core:jar:3.6.3:provided
      +- org.apache.maven:maven-resolver-provider:jar:3.6.3:provided
         \- org.apache.maven.resolver:maven-resolver-api:jar:1.4.1:provided
   ```

2. Add Dependabot ignore rules in `.github/dependabot.yml` for:
   - `org.apache.maven.resolver:*` (`>= 2.0`, which targets Maven 4)
   - `org.slf4j:*` (`>= 2.0`, which drops `StaticLoggerBinder` used by Maven 3)

Supersedes #430.